### PR TITLE
feat: Create root demo index page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,130 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>QO-DEMO 프로젝트</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+            line-height: 1.6;
+            margin: 0;
+            padding: 0;
+            background: linear-gradient(to right, #e9f5e9, #d8f0d8);
+            color: #333;
+        }
+        .container {
+            max-width: 960px;
+            margin: 2rem auto;
+            padding: 1rem;
+            background-color: #ffffff;
+            border-radius: 12px;
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+        }
+        header {
+            text-align: center;
+            padding-bottom: 1.5rem;
+            border-bottom: 1px solid #e0e0e0;
+        }
+        h1 {
+            color: #2c6b2f;
+            margin-bottom: 0.5rem;
+        }
+        h2 {
+            color: #3e8e41;
+            border-bottom: 2px solid #a5d6a7;
+            padding-bottom: 0.5rem;
+            margin-top: 2rem;
+        }
+        ul {
+            list-style-type: none;
+            padding: 0;
+        }
+        li {
+            display: flex;
+            align-items: center;
+            padding: 12px 8px;
+            border-bottom: 1px solid #f0f0f0;
+            transition: background-color 0.2s ease-in-out;
+        }
+        li:last-child {
+            border-bottom: none;
+        }
+        li:hover {
+            background-color: #f5fbf5;
+        }
+        .page-id {
+            font-weight: bold;
+            color: #4caf50;
+            background-color: #e8f5e9;
+            padding: 4px 8px;
+            border-radius: 6px;
+            margin-right: 16px;
+            font-size: 0.9em;
+        }
+        a {
+            text-decoration: none;
+            color: #333;
+            font-weight: 500;
+            flex-grow: 1;
+        }
+        a:hover {
+            color: #1b5e20;
+        }
+        .comment {
+            text-align: center;
+            margin-top: 2rem;
+            font-size: 0.9em;
+            color: #666;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <header>
+            <h1>QO-DEMO 프로젝트</h1>
+            <p>전체 데모 페이지 링크 목록</p>
+        </header>
+
+        <main>
+            <!--
+                참고: 아래 링크들은 각 .tsx 소스 파일을 직접 가리키고 있습니다.
+                실제 서비스에서는 React Router와 같은 라우팅 라이브러리를 사용하여
+                이 경로들을 실제 페이지 컴포넌트와 연결해야 합니다.
+            -->
+
+            <section id="customer-pages">
+                <h2>👥 고객용 페이지 (QO-C)</h2>
+                <ul>
+                    <li><span class="page-id">QO-C001</span> <a href="./qo_c001_landing.tsx">Landing/Welcome Page</a></li>
+                    <li><span class="page-id">QO-C002</span> <a href="./qo_c002_menu.tsx">Menu Catalog</a></li>
+                    <li><span class="page-id">QO-C003</span> <a href="./qo_c003_item_details.tsx">Item Details</a></li>
+                    <li><span class="page-id">QO-C004</span> <a href="./qo_c004_cart.tsx">Shopping Cart</a></li>
+                    <li><span class="page-id">QO-C005</span> <a href="./qo_c005_checkout.tsx">Checkout</a></li>
+                    <li><span class="page-id">QO-C006</span> <a href="./qo_c006_payment.tsx">Payment</a></li>
+                    <li><span class="page-id">QO-C007</span> <a href="./qo_c007_order_status.tsx">Order Status</a></li>
+                    <li><span class="page-id">QO-C008</span> <a href="./qo_c008_confirmation.tsx">Order Confirmation</a></li>
+                </ul>
+            </section>
+
+            <section id="staff-pages">
+                <h2>🛠️ 직원용 페이지 (QO-S)</h2>
+                <ul>
+                    <li><span class="page-id">QO-S001</span> <a href="./qo_s001_staff_login.tsx">Staff Login</a></li>
+                    <li><span class="page-id">QO-S002</span> <a href="./qo_s002_dashboard.tsx">Staff Dashboard</a></li>
+                    <li><span class="page-id">QO-S003</span> <a href="./qo_s003_order_management.tsx">Order Management</a></li>
+                    <li><span class="page-id">QO-S004</span> <a href="./qo_s004_kitchen_display.tsx">Kitchen Display</a></li>
+                    <li><span class="page-id">QO-S005</span> <a href="./qo_s005_menu_management.tsx">Menu Management</a></li>
+                    <li><span class="page-id">QO-S006</span> <a href="./qo_s006_table_management.tsx">Table Management</a></li>
+                    <li><span class="page-id">QO-S007</span> <a href="./qo_s007_customer_service.tsx">Customer Service</a></li>
+                    <li><span class="page-id">QO-S008</span> <a href="./qo_s008_staff_analytics.tsx">Staff Analytics</a></li>
+                </ul>
+            </section>
+        </main>
+
+        <footer class="comment">
+            <p>각 링크는 React Router 등을 통해 실제 웹페이지 경로와 연결되어야 합니다.</p>
+        </footer>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
Adds an `index.html` file to serve as a central hub for all demo pages.

The page lists all customer-facing (QO-C) and staff-facing (QO-S) components. Each entry links directly to its corresponding `.tsx` source file for easy reference during development.

Includes a clean, modern design with basic CSS, reflecting the project's aesthetic. This addresses the user's request to create a root page providing links to all available demos.