### PR TITLE
feat: Add homepage and iPhone frame layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,59 @@
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+
+// Layout Component (will be created later)
+import iPhoneFrame from './components/iPhoneFrame';
+
+// Page Components
+import HomePage from './pages/HomePage';
+import QoC001Landing from './pages/qo_c001_landing';
+import QoC002Menu from './pages/qo_c002_menu';
+import QoC003ItemDetails from './pages/qo_c003_item_details';
+import QoC004Cart from './pages/qo_c004_cart';
+import QoC005Checkout from './pages/qo_c005_checkout';
+import QoC006Payment from './pages/qo_c006_payment';
+import QoC007OrderStatus from './pages/qo_c007_order_status';
+import QoC008Confirmation from './pages/qo_c008_confirmation';
+import QoS001StaffLogin from './pages/qo_s001_staff_login';
+import QoS002Dashboard from './pages/qo_s002_dashboard';
+import QoS003OrderManagement from './pages/qo_s003_order_management';
+import QoS004KitchenDisplay from './pages/qo_s004_kitchen_display';
+import QoS005MenuManagement from './pages/qo_s005_menu_management';
+import QoS006TableManagement from './pages/qo_s006_table_management';
+import QoS007CustomerService from './pages/qo_s007_customer_service';
+import QoS008StaffAnalytics from './pages/qo_s008_staff_analytics';
+
+function App() {
+  // A helper function to wrap routes with the iPhone frame
+  const framed = (element: React.ReactNode) => <iPhoneFrame>{element}</iPhoneFrame>;
+
+  return (
+    <BrowserRouter>
+      <Routes>
+        {/* Homepage without the frame */}
+        <Route path="/" element={<HomePage />} />
+
+        {/* Customer Pages */}
+        <Route path="/qo-c-001" element={framed(<QoC001Landing />)} />
+        <Route path="/qo-c-002" element={framed(<QoC002Menu />)} />
+        <Route path="/qo-c-003" element={framed(<QoC003ItemDetails />)} />
+        <Route path="/qo-c-004" element={framed(<QoC004Cart />)} />
+        <Route path="/qo-c-005" element={framed(<QoC005Checkout />)} />
+        <Route path="/qo-c-006" element={framed(<QoC006Payment />)} />
+        <Route path="/qo-c-007" element={framed(<QoC007OrderStatus />)} />
+        <Route path="/qo-c-008" element={framed(<QoC008Confirmation />)} />
+
+        {/* Staff Pages */}
+        <Route path="/qo-s-001" element={framed(<QoS001StaffLogin />)} />
+        <Route path="/qo-s-002" element={framed(<QoS002Dashboard />)} />
+        <Route path="/qo-s-003" element={framed(<QoS003OrderManagement />)} />
+        <Route path="/qo-s-004" element={framed(<QoS004KitchenDisplay />)} />
+        <Route path="/qo-s-005" element={framed(<QoS005MenuManagement />)} />
+        <Route path="/qo-s-006" element={framed(<QoS006TableManagement />)} />
+        <Route path="/qo-s-007" element={framed(<QoS007CustomerService />)} />
+        <Route path="/qo-s-008" element={framed(<QoS008StaffAnalytics />)} />
+      </Routes>
+    </BrowserRouter>
+  );
+}
+
+export default App;

--- a/src/components/iPhoneFrame.css
+++ b/src/components/iPhoneFrame.css
@@ -1,0 +1,61 @@
+.iphone-frame-background {
+  width: 100%;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: #f0f2f5; /* A neutral background */
+  padding: 2rem;
+  box-sizing: border-box;
+}
+
+.iphone-frame {
+  width: 414px;
+  height: 896px;
+  background-color: #1c1c1e;
+  border-radius: 60px;
+  padding: 18px;
+  box-shadow: 0 20px 40px rgba(0,0,0,0.3), 0 0 0 2px #333;
+  position: relative;
+  box-sizing: border-box;
+}
+
+.iphone-notch {
+  position: absolute;
+  top: 18px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 210px;
+  height: 36px;
+  background-color: #1c1c1e;
+  border-radius: 0 0 20px 20px;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.iphone-camera {
+  width: 8px;
+  height: 8px;
+  background-color: #000;
+  border-radius: 50%;
+  margin-right: 15px;
+  border: 1px solid #444;
+}
+
+.iphone-speaker {
+  width: 70px;
+  height: 6px;
+  background-color: #000;
+  border-radius: 3px;
+}
+
+.iphone-screen {
+  width: 100%;
+  height: 100%;
+  background-color: white;
+  border-radius: 42px;
+  overflow: auto; /* Allow scrolling within the screen */
+  position: relative;
+}

--- a/src/components/iPhoneFrame.tsx
+++ b/src/components/iPhoneFrame.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import './iPhoneFrame.css';
+
+interface iPhoneFrameProps {
+  children: React.ReactNode;
+}
+
+const iPhoneFrame: React.FC<iPhoneFrameProps> = ({ children }) => {
+  return (
+    <div className="iphone-frame-background">
+      <div className="iphone-frame">
+        <div className="iphone-notch">
+          <div className="iphone-camera"></div>
+          <div className="iphone-speaker"></div>
+        </div>
+        <div className="iphone-screen">
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default iPhoneFrame;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,10 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import './index.css';
-import QoC001Landing from './pages/qo_c001_landing';
+import App from './App';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <QoC001Landing />
+    <App />
   </StrictMode>,
 );

--- a/src/pages/HomePage.css
+++ b/src/pages/HomePage.css
@@ -1,0 +1,76 @@
+/* Styles for the HomePage component */
+.home-container {
+    max-width: 960px;
+    margin: 2rem auto;
+    padding: 1rem;
+    background-color: #ffffff;
+    border-radius: 12px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+    color: #333;
+}
+
+.home-header {
+    text-align: center;
+    padding-bottom: 1.5rem;
+    border-bottom: 1px solid #e0e0e0;
+}
+
+.home-header h1 {
+    color: #2c6b2f;
+    margin-bottom: 0.5rem;
+}
+
+.home-header .comment {
+    font-size: 0.9em;
+    color: #666;
+    margin-top: 0.5rem;
+}
+
+.home-container h2 {
+    color: #3e8e41;
+    border-bottom: 2px solid #a5d6a7;
+    padding-bottom: 0.5rem;
+    margin-top: 2rem;
+}
+
+.home-container ul {
+    list-style-type: none;
+    padding: 0;
+}
+
+.home-container li {
+    display: flex;
+    align-items: center;
+    padding: 12px 8px;
+    border-bottom: 1px solid #f0f0f0;
+    transition: background-color 0.2s ease-in-out;
+}
+
+.home-container li:last-child {
+    border-bottom: none;
+}
+
+.home-container li:hover {
+    background-color: #f5fbf5;
+}
+
+.page-id {
+    font-weight: bold;
+    color: #4caf50;
+    background-color: #e8f5e9;
+    padding: 4px 8px;
+    border-radius: 6px;
+    margin-right: 16px;
+    font-size: 0.9em;
+}
+
+.home-container a {
+    text-decoration: none;
+    color: #333;
+    font-weight: 500;
+    flex-grow: 1;
+}
+
+.home-container a:hover {
+    color: #1b5e20;
+}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import './HomePage.css';
+
+const HomePage: React.FC = () => {
+    return (
+        <div className="home-container">
+            <header className="home-header">
+                <h1>QO-DEMO 프로젝트</h1>
+                <p>전체 데모 페이지 링크 목록</p>
+                <p className="comment">각 페이지는 아이폰 프레임 안에서 보여집니다.</p>
+            </header>
+
+            <main>
+                <section id="customer-pages">
+                    <h2>👥 고객용 페이지 (QO-C)</h2>
+                    <ul>
+                        <li><span className="page-id">QO-C001</span> <Link to="/qo-c-001">Landing/Welcome Page</Link></li>
+                        <li><span className="page-id">QO-C002</span> <Link to="/qo-c-002">Menu Catalog</Link></li>
+                        <li><span className="page-id">QO-C003</span> <Link to="/qo-c-003">Item Details</Link></li>
+                        <li><span className="page-id">QO-C004</span> <Link to="/qo-c-004">Shopping Cart</Link></li>
+                        <li><span className="page-id">QO-C005</span> <Link to="/qo-c-005">Checkout</Link></li>
+                        <li><span className="page-id">QO-C006</span> <Link to="/qo-c-006">Payment</Link></li>
+                        <li><span className="page-id">QO-C007</span> <Link to="/qo-c-007">Order Status</Link></li>
+                        <li><span className="page-id">QO-C008</span> <Link to="/qo-c-008">Order Confirmation</Link></li>
+                    </ul>
+                </section>
+
+                <section id="staff-pages">
+                    <h2>🛠️ 직원용 페이지 (QO-S)</h2>
+                    <ul>
+                        <li><span className="page-id">QO-S001</span> <Link to="/qo-s-001">Staff Login</Link></li>
+                        <li><span className="page-id">QO-S002</span> <Link to="/qo-s-002">Staff Dashboard</Link></li>
+                        <li><span className="page-id">QO-S003</span> <Link to="/qo-s-003">Order Management</Link></li>
+                        <li><span className="page-id">QO-S004</span> <Link to="/qo-s-004">Kitchen Display</Link></li>
+                        <li><span className="page-id">QO-S005</span> <Link to="/qo-s-005">Menu Management</Link></li>
+                        <li><span className="page-id">QO-S006</span> <Link to="/qo-s-006">Table Management</Link></li>
+                        <li><span className="page-id">QO-S007</span> <Link to="/qo-s-007">Customer Service</Link></li>
+                        <li><span className="page-id">QO-S008</span> <Link to="/qo-s-008">Staff Analytics</Link></li>
+                    </ul>
+                </section>
+            </main>
+        </div>
+    );
+};
+
+export default HomePage;


### PR DESCRIPTION
- Re-implements the application router and a homepage with organized links to all demo pages.
- Introduces a new `iPhoneFrame.tsx` layout component that wraps each sample page to display it within a realistic iPhone-like frame.
- Integrates the layout with React Router, applying the frame to all sample pages while leaving the homepage as a full-width page.
- This fulfills the user's request for a central navigation page and a framed presentation for the demos.