### PR TITLE
fix: Correct PascalCase for IphoneFrame component

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 
-// Layout Component (will be created later)
-import iPhoneFrame from './components/iPhoneFrame';
+// Layout Component
+import IphoneFrame from './components/iPhoneFrame';
 
 // Page Components
 import HomePage from './pages/HomePage';
@@ -25,7 +25,7 @@ import QoS008StaffAnalytics from './pages/qo_s008_staff_analytics';
 function App() {
   console.log('[App.tsx] Router component rendering. Setting up routes.');
   // A helper function to wrap routes with the iPhone frame
-  const framed = (element: React.ReactNode) => <iPhoneFrame>{element}</iPhoneFrame>;
+  const framed = (element: React.ReactNode) => <IphoneFrame>{element}</IphoneFrame>;
 
   return (
     <BrowserRouter>

--- a/src/components/iPhoneFrame.tsx
+++ b/src/components/iPhoneFrame.tsx
@@ -4,9 +4,9 @@ interface iPhoneFrameProps {
   children: React.ReactNode;
 }
 
-const iPhoneFrame: React.FC<iPhoneFrameProps> = ({ children }) => {
-  console.log('[iPhoneFrame.tsx] Rendering...');
-  console.log('[iPhoneFrame.tsx] Received children:', children ? 'Yes' : 'No');
+const IphoneFrame: React.FC<iPhoneFrameProps> = ({ children }) => {
+  console.log('[IphoneFrame.tsx] Rendering...');
+  console.log('[IphoneFrame.tsx] Received children:', children ? 'Yes' : 'No');
 
   const backgroundClasses = "flex min-h-screen w-full items-center justify-center bg-gray-100 p-4 sm:p-8";
   const frameClasses = "relative mx-auto h-[896px] w-[414px] rounded-[60px] border-[14px] border-black bg-black shadow-2xl";
@@ -40,4 +40,4 @@ const iPhoneFrame: React.FC<iPhoneFrameProps> = ({ children }) => {
   );
 };
 
-export default iPhoneFrame;
+export default IphoneFrame;


### PR DESCRIPTION
Renames the `iPhoneFrame` component to `IphoneFrame` to conform to React's PascalCase convention for component naming.

Updates the component's definition file (`iPhoneFrame.tsx`) and its usage in the router (`App.tsx`).

This resolves the "incorrect casing" error reported from the browser console, which prevented the component from being recognized and rendered.