### PR TITLE
fix: Correct import path for AppHeader component

### DIFF
--- a/src/pages/qo_c001_landing.tsx
+++ b/src/pages/qo_c001_landing.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { ChevronRight, Clock, Star, QrCode } from 'lucide-react';
-import AppHeader from '../../components/AppHeader';
+import AppHeader from '../components/AppHeader';
 
 const QOLandingPage = () => {
   console.log('[qo_c001_landing.tsx] Rendering sample page inside the frame.');


### PR DESCRIPTION
Fixes an incorrect relative path in the import statement for the `AppHeader` component within `qo_c001_landing.tsx`.

The path was changed from `../../components/AppHeader` to the correct `../components/AppHeader`.

This resolves the "Failed to resolve import" error reported from Vite's import analysis.