### PR TITLE
fix: Correct unclosed JSX tag in confirmation page

### DIFF
--- a/src/pages/qo_c008_confirmation.tsx
+++ b/src/pages/qo_c008_confirmation.tsx
@@ -46,7 +46,7 @@ const QOOrderConfirmation = () => {
             {/* ... rest of the component JSX is unchanged */}
           </div>
         </div>
-      </main>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
Fixes a JSX syntax error in `qo_c008_confirmation.tsx` where a `<div>` was incorrectly closed with a `</main>` tag.

This resolves the "Expected corresponding JSX closing tag" error reported by Vite's Babel plugin.