### PR TITLE
feat: Redesign homepage as a full application showcase

### DIFF
--- a/src/pages/HomePage.css
+++ b/src/pages/HomePage.css
@@ -1,104 +1,82 @@
-/* Styles for the new Interactive Dashboard Homepage */
-.dashboard-container {
-  padding: 2rem;
-  background-color: #f7fafc;
-  min-height: 100vh;
+/* Styles for the new Showcase Homepage */
+.showcase-container {
+  background-color: #f0f2f5;
+  padding: 3rem 0;
   font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
 }
 
-.dashboard-header {
+.showcase-header {
   text-align: center;
-  margin-bottom: 3rem;
+  margin-bottom: 4rem;
+  padding: 0 2rem;
 }
 
-.dashboard-header h1 {
-  font-size: 2.25rem;
+.showcase-header h1 {
+  font-size: 2.5rem;
   font-weight: bold;
-  color: #2d3748;
+  color: #1a202c;
 }
 
-.dashboard-header p {
-  font-size: 1.125rem;
+.showcase-header p {
+  font-size: 1.25rem;
   color: #718096;
   margin-top: 0.5rem;
 }
 
-.flow-section {
-  margin-bottom: 4rem;
+.showcase-section {
+  margin-bottom: 5rem;
 }
 
 .section-title {
+  font-size: 2rem;
+  font-weight: bold;
+  color: #2d3748;
+  text-align: center;
+  margin-bottom: 3rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.showcase-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-bottom: 6rem; /* Add more space between items */
+  position: relative;
+}
+
+/* Add a connector line */
+.showcase-item:not(:last-child)::after {
+  content: '';
+  position: absolute;
+  bottom: -3rem;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 2px;
+  height: 3rem;
+  background-color: #cbd5e0;
+}
+
+.page-title {
   font-size: 1.5rem;
   font-weight: 600;
   color: #4a5568;
   margin-bottom: 1.5rem;
-  display: flex;
-  align-items: center;
-}
-
-.flow-grid {
-  display: flex;
-  align-items: center;
-  overflow-x: auto;
-  padding-bottom: 1rem;
-}
-
-.page-card {
-  flex-shrink: 0;
-  width: 220px;
-  height: 180px;
-  background-color: white;
-  border-radius: 12px;
-  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
-  padding: 1.5rem;
-  display: flex;
-  flex-direction: column;
-  transition: transform 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
-  text-decoration: none;
-  color: inherit;
-}
-
-.page-card:hover {
-  transform: translateY(-5px);
-  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
-}
-
-.card-icon {
-  color: #4299e1;
-  margin-bottom: 1rem;
-}
-
-.card-icon svg {
-  width: 32px;
-  height: 32px;
-}
-
-.card-id {
-  font-size: 0.75rem;
-  font-weight: 600;
-  color: #4a5568;
-  background-color: #e2e8f0;
+  background-color: #ffffff;
+  padding: 0.5rem 1.5rem;
   border-radius: 9999px;
-  padding: 0.25rem 0.75rem;
-  display: inline-block;
-  margin-bottom: 0.5rem;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+  border: 1px solid #e2e8f0;
 }
 
-.card-title {
-  font-size: 1.125rem;
-  font-weight: 600;
-  color: #2d3748;
+.frame-container {
+  transform: scale(0.85);
+  transform-origin: top;
+  border-radius: 68px; /* Match the iPhone frame's border-radius */
+  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
+  transition: transform 0.3s ease-in-out;
 }
 
-.card-description {
-  font-size: 0.875rem;
-  color: #718096;
-  margin-top: 0.25rem;
-}
-
-.flow-connector {
-  flex-shrink: 0;
-  font-size: 2.5rem;
-  color: #cbd5e0;
-  margin: 0 1rem;
+.showcase-item:hover .frame-container {
+  transform: scale(0.88);
 }

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,82 +1,72 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
-import {
-  Home, Coffee, ShoppingCart, CreditCard, CheckCircle, User, Settings, BarChart2,
-  Users, ClipboardList, ChefHat, LayoutGrid, MessageSquare, Star
-} from 'lucide-react';
-import './HomePage.css';
+import IphoneFrame from '../components/IphoneFrame';
+
+// Import all page components
+import QoC001 from './qo_c001_landing';
+import QoC002 from './qo_c002_menu';
+import QoC003 from './qo_c003_item_details';
+import QoC004 from './qo_c004_cart';
+import QoC005 from './qo_c005_checkout';
+import QoC006 from './qo_c006_payment';
+import QoC007 from './qo_c007_order_status';
+import QoC008 from './qo_c008_confirmation';
+import QoS001 from './qo_s001_staff_login';
+import QoS002 from './qo_s002_dashboard';
+import QoS003 from './qo_s003_order_management';
+import QoS004 from './qo_s004_kitchen_display';
+import QoS005 from './qo_s005_menu_management';
+import QoS006 from './qo_s006_table_management';
+import QoS007 from './qo_s007_customer_service';
+import QoS008 from './qo_s008_staff_analytics';
 
 const customerPages = [
-  { id: 'QO-C001', title: 'Landing Page', description: '언어 선택, 테이블 정보', icon: <Home />, link: '/qo-c-001' },
-  { id: 'QO-C002', title: 'Menu Catalog', description: '메뉴 카탈로그, 카테고리 필터', icon: <Coffee />, link: '/qo-c-002' },
-  { id: 'QO-C003', title: 'Item Details', description: '상세 페이지, 커스터마이징', icon: <Star />, link: '/qo-c-003' },
-  { id: 'QO-C004', title: 'Shopping Cart', description: '장바구니, 프로모 코드', icon: <ShoppingCart />, link: '/qo-c-004' },
-  { id: 'QO-C005', title: 'Checkout', description: '고객 정보, 결제 방법 선택', icon: <CreditCard />, link: '/qo-c-005' },
-  { id: 'QO-C008', title: 'Confirmation', description: '주문 완료, QR 코드', icon: <CheckCircle />, link: '/qo-c-008' },
+  { id: 'QO-C001', title: 'Landing Page', Component: QoC001 },
+  { id: 'QO-C002', title: 'Menu Catalog', Component: QoC002 },
+  { id: 'QO-C003', title: 'Item Details', Component: QoC003 },
+  { id: 'QO-C004', title: 'Shopping Cart', Component: QoC004 },
+  { id: 'QO-C005', title: 'Checkout', Component: QoC005 },
+  { id: 'QO-C006', title: 'Payment', Component: QoC006 },
+  { id: 'QO-C007', title: 'Order Status', Component: QoC007 },
+  { id: 'QO-C008', title: 'Confirmation', Component: QoC008 },
 ];
 
 const staffPages = [
-  { id: 'QO-S001', title: 'Staff Login', description: '다중 로그인, 보안 인증', icon: <User />, link: '/qo-s-001' },
-  { id: 'QO-S002', title: 'Dashboard', description: '개인화 대시보드, 통계', icon: <LayoutGrid />, link: '/qo-s-002' },
-  { id: 'QO-S003', title: 'Order Mgmt', description: '주문 관리, 상태별 필터링', icon: <ClipboardList />, link: '/qo-s-003' },
-  { id: 'QO-S004', title: 'Kitchen Display', description: '주방용 디스플레이, 칸반 보드', icon: <ChefHat />, link: '/qo-s-004' },
-  { id: 'QO-S005', title: 'Menu Mgmt', description: '실시간 메뉴, 재고 관리', icon: <Settings />, link: '/qo-s-005' },
-  { id: 'QO-S007', title: 'Customer Svc', description: '고객 요청 관리, 실시간 채팅', icon: <MessageSquare />, link: '/qo-s-007' },
-  { id: 'QO-S008', title: 'Analytics', description: '개인/팀 성과 분석', icon: <BarChart2 />, link: '/qo-s-008' },
+  { id: 'QO-S001', title: 'Staff Login', Component: QoS001 },
+  { id: 'QO-S002', title: 'Dashboard', Component: QoS002 },
+  { id: 'QO-S003', title: 'Order Management', Component: QoS003 },
+  { id: 'QO-S004', title: 'Kitchen Display', Component: QoS004 },
+  { id: 'QO-S005', title: 'Menu Management', Component: QoS005 },
+  { id: 'QO-S006', title: 'Table Management', Component: QoS006 },
+  { id: 'QO-S007', title: 'Customer Service', Component: QoS007 },
+  { id: 'QO-S008', title: 'Staff Analytics', Component: QoS008 },
 ];
 
-
-const PageCard = ({ id, title, description, icon, link }) => (
-  <Link to={link} className="page-card">
-    <div className="card-icon">{icon}</div>
-    <div className="card-content">
-      <div className="card-id">{id}</div>
-      <h3 className="card-title">{title}</h3>
-      <p className="card-description">{description}</p>
+const ShowcaseItem = ({ id, title, Component }) => (
+  <div className="showcase-item">
+    <h3 className="page-title">{id}: {title}</h3>
+    <div className="frame-container">
+      <IphoneFrame>
+        <Component />
+      </IphoneFrame>
     </div>
-  </Link>
+  </div>
 );
 
-const FlowConnector = () => <div className="flow-connector">→</div>;
-
 const HomePage: React.FC = () => {
-  console.log('[HomePage.tsx] Rendering interactive dashboard.');
   return (
-    <div className="dashboard-container">
-      <header className="dashboard-header">
-        <h1>QO-DEMO Interactive Dashboard</h1>
-        <p>프로젝트의 전체 구조와 사용자 흐름을 확인하세요.</p>
+    <div className="showcase-container">
+      <header className="showcase-header">
+        <h1>QO-DEMO Application Showcase</h1>
+        <p>Scroll down to see the entire application flow at a glance.</p>
       </header>
-
       <main>
-        <section className="flow-section">
-          <h2 className="section-title">
-            <Users className="inline-block mr-2" />
-            고객용 페이지 흐름 (Customer Flow)
-          </h2>
-          <div className="flow-grid">
-            {customerPages.map((page, index) => (
-              <React.Fragment key={page.id}>
-                <PageCard {...page} />
-                {index < customerPages.length - 1 && <FlowConnector />}
-              </React.Fragment>
-            ))}
-          </div>
+        <section className="showcase-section">
+          <h2 className="section-title">Customer Flow</h2>
+          {customerPages.map(page => <ShowcaseItem key={page.id} {...page} />)}
         </section>
-
-        <section className="flow-section">
-          <h2 className="section-title">
-            <Users className="inline-block mr-2" />
-            직원용 페이지 흐름 (Staff Flow)
-          </h2>
-          <div className="flow-grid">
-            {staffPages.map((page, index) => (
-              <React.Fragment key={page.id}>
-                <PageCard {...page} />
-                {index < staffPages.length - 1 && <FlowConnector />}
-              </React.Fragment>
-            ))}
-          </div>
+        <section className="showcase-section">
+          <h2 className="section-title">Staff Flow</h2>
+          {staffPages.map(page => <ShowcaseItem key={page.id} {...page} />)}
         </section>
       </main>
     </div>


### PR DESCRIPTION
- Drastically redesigns the homepage (`HomePage.tsx`) into a "showcase" or "storyboard" layout.
- The new homepage imports and renders all 16 sample pages sequentially, each within an `IphoneFrame`.
- This allows stakeholders to view the entire application flow and design in a single, scrollable page, addressing the user's request for a more intuitive presentation.
- Updates `HomePage.css` to support the new showcase layout, including section titles and spacing.