### PR TITLE
fix: Recreate App.tsx from scratch to resolve issues

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,63 +1,60 @@
+import React from 'react';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
-
-// Layout Component
-import IphoneFrame from './components/iPhoneFrame';
-
-// Page Components
-import HomePage from './pages/HomePage';
-import QoC001Landing from './pages/qo_c001_landing';
-import QoC002Menu from './pages/qo_c002_menu';
-import QoC003ItemDetails from './pages/qo_c003_item_details';
-import QoC004Cart from './pages/qo_c004_cart';
-import QoC005Checkout from './pages/qo_c005_checkout';
-import QoC006Payment from './pages/qo_c006_payment';
-import QoC007OrderStatus from './pages/qo_c007_order_status';
-import QoC008Confirmation from './pages/qo_c008_confirmation';
-import QoS001StaffLogin from './pages/qo_s001_staff_login';
-import QoS002Dashboard from './pages/qo_s002_dashboard';
-import QoS003OrderManagement from './pages/qo_s003_order_management';
-import QoS004KitchenDisplay from './pages/qo_s004_kitchen_display';
-import QoS005MenuManagement from './pages/qo_s005_menu_management';
-import QoS006TableManagement from './pages/qo_s006_table_management';
-import QoS007CustomerService from './pages/qo_s007_customer_service';
-import QoS008StaffAnalytics from './pages/qo_s008_staff_analytics';
-
 import { LanguageProvider } from './contexts/LanguageContext';
+import IphoneFrame from './components/IphoneFrame';
+
+// Import all page components
+import HomePage from './pages/HomePage';
+import QoC001 from './pages/qo_c001_landing';
+import QoC002 from './pages/qo_c002_menu';
+import QoC003 from './pages/qo_c003_item_details';
+import QoC004 from './pages/qo_c004_cart';
+import QoC005 from './pages/qo_c005_checkout';
+import QoC006 from './pages/qo_c006_payment';
+import QoC007 from './pages/qo_c007_order_status';
+import QoC008 from './pages/qo_c008_confirmation';
+import QoS001 from './pages/qo_s001_staff_login';
+import QoS002 from './pages/qo_s002_dashboard';
+import QoS003 from './pages/qo_s003_order_management';
+import QoS004 from './pages/qo_s004_kitchen_display';
+import QoS005 from './pages/qo_s005_menu_management';
+import QoS006 from './pages/qo_s006_table_management';
+import QoS007 from './pages/qo_s007_customer_service';
+import QoS008 from './pages/qo_s008_staff_analytics';
+
+const FramedPage = ({ children }: { children: React.ReactNode }) => (
+  <IphoneFrame>{children}</IphoneFrame>
+);
 
 function App() {
-  console.log('[App.tsx] Router component rendering. Setting up routes.');
-  // A helper function to wrap routes with the iPhone frame
-  const framed = (element: React.ReactNode) => <IphoneFrame>{element}</IphoneFrame>;
-
   return (
     <LanguageProvider>
       <BrowserRouter>
         <Routes>
-          {/* Homepage without the frame */}
+          {/* The showcase homepage is the root */}
           <Route path="/" element={<HomePage />} />
 
-        {/* Customer Pages */}
-        <Route path="/qo-c-001" element={framed(<QoC001Landing />)} />
-        <Route path="/qo-c-002" element={framed(<QoC002Menu />)} />
-        <Route path="/qo-c-003" element={framed(<QoC003ItemDetails />)} />
-        <Route path="/qo-c-004" element={framed(<QoC004Cart />)} />
-        <Route path="/qo-c-005" element={framed(<QoC005Checkout />)} />
-        <Route path="/qo-c-006" element={framed(<QoC006Payment />)} />
-        <Route path="/qo-c-007" element={framed(<QoC007OrderStatus />)} />
-        <Route path="/qo-c-008" element={framed(<QoC008Confirmation />)} />
+          {/* Direct routes to each page, wrapped in the iPhone Frame */}
+          <Route path="/qo-c-001" element={<FramedPage><QoC001 /></FramedPage>} />
+          <Route path="/qo-c-002" element={<FramedPage><QoC002 /></FramedPage>} />
+          <Route path="/qo-c-003" element={<FramedPage><QoC003 /></FramedPage>} />
+          <Route path="/qo-c-004" element={<FramedPage><QoC004 /></FramedPage>} />
+          <Route path="/qo-c-005" element={<FramedPage><QoC005 /></FramedPage>} />
+          <Route path="/qo-c-006" element={<FramedPage><QoC006 /></FramedPage>} />
+          <Route path="/qo-c-007" element={<FramedPage><QoC007 /></FramedPage>} />
+          <Route path="/qo-c-008" element={<FramedPage><QoC008 /></FramedPage>} />
 
-        {/* Staff Pages */}
-        <Route path="/qo-s-001" element={framed(<QoS001StaffLogin />)} />
-        <Route path="/qo-s-002" element={framed(<QoS002Dashboard />)} />
-        <Route path="/qo-s-003" element={framed(<QoS003OrderManagement />)} />
-        <Route path="/qo-s-004" element={framed(<QoS004KitchenDisplay />)} />
-        <Route path="/qo-s-005" element={framed(<QoS005MenuManagement />)} />
-        <Route path="/qo-s-006" element={framed(<QoS006TableManagement />)} />
-        <Route path="/qo-s-007" element={framed(<QoS007CustomerService />)} />
-        <Route path="/qo-s-008" element={framed(<QoS008StaffAnalytics />)} />
-      </Routes>
-    </BrowserRouter>
-  </LanguageProvider>
+          <Route path="/qo-s-001" element={<FramedPage><QoS001 /></FramedPage>} />
+          <Route path="/qo-s-002" element={<FramedPage><QoS002 /></FramedPage>} />
+          <Route path="/qo-s-003" element={<FramedPage><QoS003 /></FramedPage>} />
+          <Route path="/qo-s-004" element={<FramedPage><QoS004 /></FramedPage>} />
+          <Route path="/qo-s-005" element={<FramedPage><QoS005 /></FramedPage>} />
+          <Route path="/qo-s-006" element={<FramedPage><QoS006 /></FramedPage>} />
+          <Route path="/qo-s-007" element={<FramedPage><QoS007 /></FramedPage>} />
+          <Route path="/qo-s-008" element={<FramedPage><QoS008 /></FramedPage>} />
+        </Routes>
+      </BrowserRouter>
+    </LanguageProvider>
   );
 }
 

--- a/src/App_backup.tsx
+++ b/src/App_backup.tsx
@@ -1,0 +1,64 @@
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+
+// Layout Component
+import IphoneFrame from './components/iPhoneFrame';
+
+// Page Components
+import HomePage from './pages/HomePage';
+import QoC001Landing from './pages/qo_c001_landing';
+import QoC002Menu from './pages/qo_c002_menu';
+import QoC003ItemDetails from './pages/qo_c003_item_details';
+import QoC004Cart from './pages/qo_c004_cart';
+import QoC005Checkout from './pages/qo_c005_checkout';
+import QoC006Payment from './pages/qo_c006_payment';
+import QoC007OrderStatus from './pages/qo_c007_order_status';
+import QoC008Confirmation from './pages/qo_c008_confirmation';
+import QoS001StaffLogin from './pages/qo_s001_staff_login';
+import QoS002Dashboard from './pages/qo_s002_dashboard';
+import QoS003OrderManagement from './pages/qo_s003_order_management';
+import QoS004KitchenDisplay from './pages/qo_s004_kitchen_display';
+import QoS005MenuManagement from './pages/qo_s005_menu_management';
+import QoS006TableManagement from './pages/qo_s006_table_management';
+import QoS007CustomerService from './pages/qo_s007_customer_service';
+import QoS008StaffAnalytics from './pages/qo_s008_staff_analytics';
+
+import { LanguageProvider } from './contexts/LanguageContext';
+
+function App() {
+  console.log('[App.tsx] Router component rendering. Setting up routes.');
+  // A helper function to wrap routes with the iPhone frame
+  const framed = (element: React.ReactNode) => <IphoneFrame>{element}</IphoneFrame>;
+
+  return (
+    <LanguageProvider>
+      <BrowserRouter>
+        <Routes>
+          {/* Homepage without the frame */}
+          <Route path="/" element={<HomePage />} />
+
+        {/* Customer Pages */}
+        <Route path="/qo-c-001" element={framed(<QoC001Landing />)} />
+        <Route path="/qo-c-002" element={framed(<QoC002Menu />)} />
+        <Route path="/qo-c-003" element={framed(<QoC003ItemDetails />)} />
+        <Route path="/qo-c-004" element={framed(<QoC004Cart />)} />
+        <Route path="/qo-c-005" element={framed(<QoC005Checkout />)} />
+        <Route path="/qo-c-006" element={framed(<QoC006Payment />)} />
+        <Route path="/qo-c-007" element={framed(<QoC007OrderStatus />)} />
+        <Route path="/qo-c-008" element={framed(<QoC008Confirmation />)} />
+
+        {/* Staff Pages */}
+        <Route path="/qo-s-001" element={framed(<QoS001StaffLogin />)} />
+        <Route path="/qo-s-002" element={framed(<QoS002Dashboard />)} />
+        <Route path="/qo-s-003" element={framed(<QoS003OrderManagement />)} />
+        <Route path="/qo-s-004" element={framed(<QoS004KitchenDisplay />)} />
+        <Route path="/qo-s-005" element={framed(<QoS005MenuManagement />)} />
+        <Route path="/qo-s-006" element={framed(<QoS006TableManagement />)} />
+        <Route path="/qo-s-007" element={framed(<QoS007CustomerService />)} />
+        <Route path="/qo-s-008" element={framed(<QoS008StaffAnalytics />)} />
+      </Routes>
+    </BrowserRouter>
+  </LanguageProvider>
+  );
+}
+
+export default App;


### PR DESCRIPTION
- Recreates the main `App.tsx` file from a clean slate as requested by the user.
- This is an attempt to resolve persistent styling issues by ensuring the core application router and provider setup has no hidden problems.
- The new file correctly implements the `LanguageProvider`, `BrowserRouter`, all page routes, and the `IphoneFrame` layout wrapper.
- The old `App.tsx` is preserved as `App_backup.tsx`.