### PR TITLE
fix: Add LanguageProvider to minimal test case

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,9 +2,12 @@ import React from 'react';
 import { createRoot } from 'react-dom/client';
 import './index.css';
 import QoC001Landing from './pages/qo_c001_landing';
+import { LanguageProvider } from './contexts/LanguageContext';
 
 createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <QoC001Landing />
+    <LanguageProvider>
+      <QoC001Landing />
+    </LanguageProvider>
   </React.StrictMode>
 );


### PR DESCRIPTION
- Wraps the test component in `main.tsx` with the `LanguageProvider`.
- This fixes a root-level crash caused by a component trying to access a context that wasn't provided.
- This submission is for the user to verify that the minimal test case (a red box) now renders correctly, which will confirm the build and styling pipeline is working.