### PR TITLE
Create a new root page with links to all sample pages.

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { LanguageProvider } from './contexts/LanguageContext';
-import IphoneFrame from './components/IphoneFrame';
+import IphoneFrame from './components/iPhoneFrame';
 
 // Import all page components
 import HomePage from './pages/HomePage';

--- a/src/components/PageLayout.tsx
+++ b/src/components/PageLayout.tsx
@@ -1,4 +1,5 @@
-import React, { ReactNode } from 'react';
+import React from 'react';
+import type { ReactNode } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { ChevronLeft } from 'lucide-react';
 import AppHeader from './AppHeader'; // The truly global header (QR, App Name)

--- a/src/contexts/LanguageContext.tsx
+++ b/src/contexts/LanguageContext.tsx
@@ -1,4 +1,5 @@
-import React, { createContext, useState, useContext, ReactNode } from 'react';
+import { createContext, useState, useContext } from 'react';
+import type { ReactNode } from 'react';
 
 // Define the shape of the language and the context
 type Language = 'en' | 'ko';

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,122 +1,85 @@
 import React from 'react';
-import IphoneFrame from '../components/IphoneFrame';
-import { CheckCircle, Users, Languages, DollarSign, Smartphone, Tv } from 'lucide-react';
-
-// Import all page components
-import QoC001 from './qo_c001_landing';
-import QoC002 from './qo_c002_menu';
-import QoC003 from './qo_c003_item_details';
-import QoC004 from './qo_c004_cart';
-import QoC005 from './qo_c005_checkout';
-import QoC006 from './qo_c006_payment';
-import QoC007 from './qo_c007_order_status';
-import QoC008 from './qo_c008_confirmation';
-import QoS001 from './qo_s001_staff_login';
-import QoS002 from './qo_s002_dashboard';
-import QoS003 from './qo_s003_order_management';
-import QoS004 from './qo_s004_kitchen_display';
-import QoS005 from './qo_s005_menu_management';
-import QoS006 from './qo_s006_table_management';
-import QoS007 from './qo_s007_customer_service';
-import QoS008 from './qo_s008_staff_analytics';
+import { Link } from 'react-router-dom';
+import { ExternalLink, Users, Briefcase } from 'lucide-react';
 
 const customerPages = [
-  { id: 'QO-C001', title: 'Landing/Welcome Page', description: 'QR 스캔 후 첫 화면. 언어 선택(EN/KO), 테이블 정보, 실시간 시계, 핵심 기능 미리보기를 제공합니다.', Component: QoC001 },
-  { id: 'QO-C002', title: 'Menu Catalog', description: '메뉴 카탈로그. 카테고리 필터, 검색, 실시간 가격 변환(AUD/KRW), 평점/리뷰를 표시합니다.', Component: QoC002 },
-  { id: 'QO-C003', title: 'Item Details', description: '메뉴 상세 정보, 옵션 커스터마이징(빵, 계란 등), 수량 선택 및 특별 요청사항을 입력합니다.', Component: QoC003 },
-  { id: 'QO-C004', title: 'Shopping Cart', description: '장바구니 관리, 수량 조절, 프로모 코드 적용 및 예상 조리시간을 표시합니다.', Component: QoC004 },
-  { id: 'QO-C005', title: 'Checkout', description: '고객 정보 입력, 서비스 유형 선택, 다양한 결제 방법(Apple/Google Pay 등)을 선택합니다.', Component: QoC005 },
-  { id: 'QO-C006', title: 'Payment', description: '실제 결제 처리. 카드 정보 마스킹, 256비트 SSL, 생체 인증(Touch/Face ID)을 지원합니다.', Component: QoC006 },
-  { id: 'QO-C007', title: 'Order Status', description: '주문 상태(확인/조리중/픽업대기)를 실시간으로 추적하고 직원을 호출합니다.', Component: QoC007 },
-  { id: 'QO-C008', title: 'Order Confirmation', description: '주문 완료를 최종 확인하고, QR 추적 코드와 로열티 포인트를 제공하며 재주문 기능을 지원합니다.', Component: QoC008 },
+  { href: '/qo-c-001', title: 'QO-C001: Landing Page' },
+  { href: '/qo-c-002', title: 'QO-C002: Menu Catalog' },
+  { href: '/qo-c-003', title: 'QO-C003: Item Details' },
+  { href: '/qo-c-004', title: 'QO-C004: Shopping Cart' },
+  { href: '/qo-c-005', title: 'QO-C005: Checkout' },
+  { href: '/qo-c-006', title: 'QO-C006: Payment' },
+  { href: '/qo-c-007', title: 'QO-C007: Order Status' },
+  { href: '/qo-c-008', title: 'QO-C008: Order Confirmation' },
 ];
 
-// NOTE: Staff pages are defined but not rendered in the final JSX, per user's last detailed description.
-// This can be easily added back if needed.
 const staffPages = [
-  { id: 'QO-S001', title: 'Staff Login', description: '역할(매니저, 셰프, 서버)별 보안 로그인. PIN, QR 등 다중 방식을 지원합니다.', Component: QoS001 },
-  { id: 'QO-S002', title: 'Dashboard', description: '개인화된 대시보드. 핵심 KPI, 실시간 근무 시간 및 활동 피드를 제공합니다.', Component: QoS002 },
-  // ... other staff pages
+  { href: '/qo-s-001', title: 'QO-S001: Staff Login' },
+  { href: '/qo-s-002', title: 'QO-S002: Dashboard' },
+  { href: '/qo-s-003', title: 'QO-S003: Order Management' },
+  { href: '/qo-s-004', title: 'QO-S004: Kitchen Display' },
+  { href: '/qo-s-005', title: 'QO-S005: Menu Management' },
+  { href: '/qo-s-006', title: 'QO-S006: Table Management' },
+  { href: '/qo-s-007', title: 'QO-S007: Customer Service' },
+  { href: '/qo-s-008', title: 'QO-S008: Staff Analytics' },
 ];
 
-const ShowcaseItem = ({ id, title, description, Component }) => (
-  <div className="showcase-item">
-    <div className="page-title-container">
-      <h3 className="page-title">{id}: {title}</h3>
-      <p className="page-description">{description}</p>
-    </div>
-    <div className="frame-container">
-      <IphoneFrame>
-        <Component />
-      </IphoneFrame>
-    </div>
-  </div>
-);
-
-const FeatureCard = ({ icon, title, description }) => (
-  <div className="feature-card">
-    <div className="feature-icon">{icon}</div>
-    <strong>{title}</strong>
-    <p>{description}</p>
-  </div>
-);
-
-const JourneyStep = ({ number, title, pageId }) => (
-  <div className="journey-step">
-    <div className="step-number">{number}</div>
-    <div className="step-details">
-      <div className="step-title">{title}</div>
-      <div className="step-page-id">{pageId}</div>
-    </div>
-  </div>
+const PageLink: React.FC<{ href: string; title: string }> = ({ href, title }) => (
+  <li className="mb-2">
+    <Link
+      to={href}
+      className="flex items-center justify-between p-3 bg-gray-50 hover:bg-gray-100 rounded-lg transition-colors duration-200"
+    >
+      <span className="font-medium text-gray-700">{title}</span>
+      <ExternalLink className="w-5 h-5 text-gray-400" />
+    </Link>
+  </li>
 );
 
 const HomePage: React.FC = () => {
   return (
-    <div className="showcase-container">
-      <header className="showcase-header">
-        <h1>QO-DEMO Application Showcase</h1>
-        <p className="intro-text">A modern, QR-based smart dining solution designed to streamline the ordering process for both customers and staff.</p>
-      </header>
-      <main>
-        <section className="showcase-section">
-          <h2 className="section-title">🌟 Key Features</h2>
-          <div className="features-grid">
-            <FeatureCard icon={<Languages />} title="다국어 지원" description="영어/한국어 실시간 전환" />
-            <FeatureCard icon={<DollarSign />} title="다중 통화" description="AUD/KRW 자동 변환" />
-            <FeatureCard icon={<Smartphone />} title="모바일 최적화" description="스마트폰 우선 반응형 디자인" />
-            <FeatureCard icon={<Tv />} title="실시간 기능" description="가격, 재고, 상태 실시간 업데이트" />
-            <FeatureCard icon={<Users />} title="사용자 친화적" description="직관적 UI/UX, 이모지 활용" />
-            <FeatureCard icon={<CheckCircle />} title="보안 강화" description="결제 보안, 생체 인증 지원" />
-          </div>
-        </section>
+    <div className="bg-gray-50 min-h-screen">
+      <div className="max-w-4xl mx-auto py-12 px-4 sm:px-6 lg:px-8">
+        <div className="text-center">
+          <h1 className="text-4xl font-extrabold text-gray-900 sm:text-5xl md:text-6xl">
+            viatable
+          </h1>
+          <p className="mt-3 max-w-md mx-auto text-base text-gray-500 sm:text-lg md:mt-5 md:text-xl md:max-w-3xl">
+            viatable will be launched in December. Simultaneous service open in Korea/Australia.
+          </p>
+          <p className="mt-3 max-w-md mx-auto text-base text-gray-500 sm:text-lg md:mt-5 md:text-xl md:max-w-3xl">
+            (viatable 12월에 오픈 예정. 한국/호주 동시 서비스 오픈.)
+          </p>
+        </div>
 
-        <section className="showcase-section">
-          <h2 className="section-title">🔄 완전한 고객 여정 (Customer Journey)</h2>
-          <div className="journey-grid">
-            <JourneyStep number="1" title="QR 스캔" pageId="QO-C001 환영 페이지" />
-            <div className="journey-arrow">→</div>
-            <JourneyStep number="2" title="메뉴 탐색" pageId="QO-C002 메뉴 카탈로그" />
-            <div className="journey-arrow">→</div>
-            <JourneyStep number="3" title="상품 선택" pageId="QO-C003 상품 상세" />
-            <div className="journey-arrow">→</div>
-            <JourneyStep number="4" title="장바구니 관리" pageId="QO-C004 장바구니" />
-            <div className="journey-arrow">→</div>
-            <JourneyStep number="5" title="정보 입력" pageId="QO-C005 체크아웃" />
-            <div className="journey-arrow">→</div>
-            <JourneyStep number="6" title="결제 처리" pageId="QO-C006 결제" />
-            <div className="journey-arrow">→</div>
-            <JourneyStep number="7" title="주문 추적" pageId="QO-C007 주문 상태" />
-            <div className="journey-arrow">→</div>
-            <JourneyStep number="8" title="완료 확인" pageId="QO-C008 주문 확인" />
+        <div className="mt-16 grid gap-12 md:grid-cols-2">
+          {/* Customer Pages */}
+          <div className="bg-white p-6 rounded-xl shadow-md">
+            <h2 className="text-2xl font-bold text-gray-800 mb-4 flex items-center">
+              <Users className="w-7 h-7 mr-3 text-indigo-500" />
+              Customer Pages
+            </h2>
+            <ul>
+              {customerPages.map((page) => (
+                <PageLink key={page.href} {...page} />
+              ))}
+            </ul>
           </div>
-        </section>
 
-        <section className="showcase-section">
-          <h2 className="section-title">📱 고객용 페이지 (QO-C)</h2>
-          {customerPages.map(page => <ShowcaseItem key={page.id} {...page} />)}
-        </section>
-      </main>
+          {/* Staff Pages */}
+          <div className="bg-white p-6 rounded-xl shadow-md">
+            <h2 className="text-2xl font-bold text-gray-800 mb-4 flex items-center">
+              <Briefcase className="w-7 h-7 mr-3 text-green-500" />
+              Staff Pages
+            </h2>
+            <ul>
+              {staffPages.map((page) => (
+                <PageLink key={page.href} {...page} />
+              ))}
+            </ul>
+          </div>
+        </div>
+      </div>
     </div>
   );
 };

--- a/src/pages/HomePage_showcase.tsx
+++ b/src/pages/HomePage_showcase.tsx
@@ -1,0 +1,129 @@
+import React from 'react';
+import IphoneFrame from '../components/iPhoneFrame';
+import { CheckCircle, Users, Languages, DollarSign, Smartphone, Tv } from 'lucide-react';
+
+import type { ReactNode, ComponentType } from 'react';
+
+// Import all page components
+import QoC001 from './qo_c001_landing';
+import QoC002 from './qo_c002_menu';
+import QoC003 from './qo_c003_item_details';
+import QoC004 from './qo_c004_cart';
+import QoC005 from './qo_c005_checkout';
+import QoC006 from './qo_c006_payment';
+import QoC007 from './qo_c007_order_status';
+import QoC008 from './qo_c008_confirmation';
+
+const customerPages = [
+  { id: 'QO-C001', title: 'Landing/Welcome Page', description: 'QR 스캔 후 첫 화면. 언어 선택(EN/KO), 테이블 정보, 실시간 시계, 핵심 기능 미리보기를 제공합니다.', Component: QoC001 },
+  { id: 'QO-C002', title: 'Menu Catalog', description: '메뉴 카탈로그. 카테고리 필터, 검색, 실시간 가격 변환(AUD/KRW), 평점/리뷰를 표시합니다.', Component: QoC002 },
+  { id: 'QO-C003', title: 'Item Details', description: '메뉴 상세 정보, 옵션 커스터마이징(빵, 계란 등), 수량 선택 및 특별 요청사항을 입력합니다.', Component: QoC003 },
+  { id: 'QO-C004', title: 'Shopping Cart', description: '장바구니 관리, 수량 조절, 프로모 코드 적용 및 예상 조리시간을 표시합니다.', Component: QoC004 },
+  { id: 'QO-C005', title: 'Checkout', description: '고객 정보 입력, 서비스 유형 선택, 다양한 결제 방법(Apple/Google Pay 등)을 선택합니다.', Component: QoC005 },
+  { id: 'QO-C006', title: 'Payment', description: '실제 결제 처리. 카드 정보 마스킹, 256비트 SSL, 생체 인증(Touch/Face ID)을 지원합니다.', Component: QoC006 },
+  { id: 'QO-C007', title: 'Order Status', description: '주문 상태(확인/조리중/픽업대기)를 실시간으로 추적하고 직원을 호출합니다.', Component: QoC007 },
+  { id: 'QO-C008', title: 'Order Confirmation', description: '주문 완료를 최종 확인하고, QR 추적 코드와 로열티 포인트를 제공하며 재주문 기능을 지원합니다.', Component: QoC008 },
+];
+
+interface ShowcaseItemProps {
+  id: string;
+  title: string;
+  description: string;
+  Component: ComponentType;
+}
+
+const ShowcaseItem: React.FC<ShowcaseItemProps> = ({ id, title, description, Component }) => (
+  <div className="showcase-item">
+    <div className="page-title-container">
+      <h3 className="page-title">{id}: {title}</h3>
+      <p className="page-description">{description}</p>
+    </div>
+    <div className="frame-container">
+      <IphoneFrame>
+        <Component />
+      </IphoneFrame>
+    </div>
+  </div>
+);
+
+interface FeatureCardProps {
+  icon: ReactNode;
+  title: string;
+  description: string;
+}
+
+const FeatureCard: React.FC<FeatureCardProps> = ({ icon, title, description }) => (
+  <div className="feature-card">
+    <div className="feature-icon">{icon}</div>
+    <strong>{title}</strong>
+    <p>{description}</p>
+  </div>
+);
+
+interface JourneyStepProps {
+  number: string;
+  title: string;
+  pageId: string;
+}
+
+const JourneyStep: React.FC<JourneyStepProps> = ({ number, title, pageId }) => (
+  <div className="journey-step">
+    <div className="step-number">{number}</div>
+    <div className="step-details">
+      <div className="step-title">{title}</div>
+      <div className="step-page-id">{pageId}</div>
+    </div>
+  </div>
+);
+
+const HomePage: React.FC = () => {
+  return (
+    <div className="showcase-container">
+      <header className="showcase-header">
+        <h1>QO-DEMO Application Showcase</h1>
+        <p className="intro-text">A modern, QR-based smart dining solution designed to streamline the ordering process for both customers and staff.</p>
+      </header>
+      <main>
+        <section className="showcase-section">
+          <h2 className="section-title">🌟 Key Features</h2>
+          <div className="features-grid">
+            <FeatureCard icon={<Languages />} title="다국어 지원" description="영어/한국어 실시간 전환" />
+            <FeatureCard icon={<DollarSign />} title="다중 통화" description="AUD/KRW 자동 변환" />
+            <FeatureCard icon={<Smartphone />} title="모바일 최적화" description="스마트폰 우선 반응형 디자인" />
+            <FeatureCard icon={<Tv />} title="실시간 기능" description="가격, 재고, 상태 실시간 업데이트" />
+            <FeatureCard icon={<Users />} title="사용자 친화적" description="직관적 UI/UX, 이모지 활용" />
+            <FeatureCard icon={<CheckCircle />} title="보안 강화" description="결제 보안, 생체 인증 지원" />
+          </div>
+        </section>
+
+        <section className="showcase-section">
+          <h2 className="section-title">🔄 완전한 고객 여정 (Customer Journey)</h2>
+          <div className="journey-grid">
+            <JourneyStep number="1" title="QR 스캔" pageId="QO-C001 환영 페이지" />
+            <div className="journey-arrow">→</div>
+            <JourneyStep number="2" title="메뉴 탐색" pageId="QO-C002 메뉴 카탈로그" />
+            <div className="journey-arrow">→</div>
+            <JourneyStep number="3" title="상품 선택" pageId="QO-C003 상품 상세" />
+            <div className="journey-arrow">→</div>
+            <JourneyStep number="4" title="장바구니 관리" pageId="QO-C004 장바구니" />
+            <div className="journey-arrow">→</div>
+            <JourneyStep number="5" title="정보 입력" pageId="QO-C005 체크아웃" />
+            <div className="journey-arrow">→</div>
+            <JourneyStep number="6" title="결제 처리" pageId="QO-C006 결제" />
+            <div className="journey-arrow">→</div>
+            <JourneyStep number="7" title="주문 추적" pageId="QO-C007 주문 상태" />
+            <div className="journey-arrow">→</div>
+            <JourneyStep number="8" title="완료 확인" pageId="QO-C008 주문 확인" />
+          </div>
+        </section>
+
+        <section className="showcase-section">
+          <h2 className="section-title">📱 고객용 페이지 (QO-C)</h2>
+          {customerPages.map(page => <ShowcaseItem key={page.id} {...page} />)}
+        </section>
+      </main>
+    </div>
+  );
+};
+
+export default HomePage;

--- a/src/pages/qo_c001_landing.tsx
+++ b/src/pages/qo_c001_landing.tsx
@@ -1,5 +1,4 @@
-import React, { useState, useEffect } from 'react';
-import { ChevronRight, Clock, Star, QrCode } from 'lucide-react';
+import { useState, useEffect } from 'react';
 import { useLanguage } from '../contexts/LanguageContext';
 
 // This is a "naked" version of the component with all styles removed for debugging.

--- a/src/pages/qo_c002_menu.tsx
+++ b/src/pages/qo_c002_menu.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
-import { Search, Star, Plus, Clock, Leaf } from 'lucide-react';
+import { useState } from 'react';
+import { Search, Plus } from 'lucide-react';
 import PageLayout from '../components/PageLayout';
 import { useLanguage } from '../contexts/LanguageContext';
 

--- a/src/pages/qo_c003_item_details.tsx
+++ b/src/pages/qo_c003_item_details.tsx
@@ -1,15 +1,12 @@
-import React, { useState } from 'react';
-import { Star, Clock, Leaf, Plus, Minus, Heart, Info, Users } from 'lucide-react';
+import { useState } from 'react';
+import { Plus, Minus, Heart } from 'lucide-react';
 import PageLayout from '../components/PageLayout';
 import { useLanguage } from '../contexts/LanguageContext';
 
 const QOItemDetails = () => {
   const { language } = useLanguage();
   const [quantity, setQuantity] = useState(1);
-  const [selectedCustomizations, setSelectedCustomizations] = useState({});
-  const [specialNotes, setSpecialNotes] = useState('');
   const [isFavorite, setIsFavorite] = useState(false);
-  const [showNutrition, setShowNutrition] = useState(false);
 
   const content = {
     en: { addToCart: "Add to Cart", quantity: "Quantity", customizations: "Customizations", specialNotes: "Special Notes", notesPlaceholder: "Any special requests?", ingredients: "Ingredients", nutrition: "Nutrition Info", allergens: "Contains", currency: "AUD" },
@@ -22,11 +19,6 @@ const QOItemDetails = () => {
     price: { AUD: 18.50, KRW: 26500 }, prepTime: 12, servings: 1, rating: 4.9, reviews: 203, calories: 450, tags: ['popular', 'vegetarian'],
     allergens: { en: ['Gluten', 'Dairy', 'Eggs'], ko: ['글루텐', '유제품', '달걀'] },
     ingredients: { en: ['Sourdough', 'Avocado', 'Egg', 'Feta'], ko: ['사워도우', '아보카도', '계란', '페타치즈'] }
-  };
-
-  const customizationOptions = {
-    en: { 'Bread Type': { options: ['Sourdough', 'Multigrain (+$1)'], prices: [0, 1] }, 'Egg Style': { options: ['Poached', 'Fried'], prices: [0, 0] } },
-    ko: { '빵 종류': { options: ['사워도우', '멀티그레인 (+1천원)'], prices: [0, 1500] }, '계란 스타일': { options: ['수란', '후라이'], prices: [0, 0] } }
   };
 
   const currentContent = content[language];

--- a/src/pages/qo_c004_cart.tsx
+++ b/src/pages/qo_c004_cart.tsx
@@ -1,13 +1,11 @@
-import React, { useState } from 'react';
-import { Plus, Minus, Trash2, Tag, ArrowRight } from 'lucide-react';
+import { useState } from 'react';
+import { Plus, Minus, Trash2, ArrowRight } from 'lucide-react';
 import PageLayout from '../components/PageLayout';
 import { useLanguage } from '../contexts/LanguageContext';
 
 const QOShoppingCart = () => {
   const { language } = useLanguage();
-  const [promoCode, setPromoCode] = useState('');
-  const [appliedPromo, setAppliedPromo] = useState(null);
-  const [cartItems, setCartItems] = useState([
+  const [cartItems] = useState([
     { id: 1, name: { en: 'Avocado Toast Supreme', ko: '슈프림 아보카도 토스트' }, price: { AUD: 22.50, KRW: 32500 }, quantity: 2, image: '🥑' },
     { id: 2, name: { en: 'Oat Milk Latte', ko: '오트밀크 라떼' }, price: { AUD: 7.20, KRW: 10500 }, quantity: 1, image: '☕' },
   ]);

--- a/src/pages/qo_c005_checkout.tsx
+++ b/src/pages/qo_c005_checkout.tsx
@@ -1,16 +1,10 @@
-import React, { useState } from 'react';
-import { Clock, CreditCard, Smartphone, QrCode, User, Mail, Phone, MapPin, AlertCircle, CheckCircle, ArrowRight, Edit3 } from 'lucide-react';
+import { useState } from 'react';
 import PageLayout from '../components/PageLayout';
 import { useLanguage } from '../contexts/LanguageContext';
 
 const QOCheckout = () => {
   const { language } = useLanguage();
-  const [selectedPaymentMethod, setSelectedPaymentMethod] = useState('card');
-  const [customerInfo, setCustomerInfo] = useState({ name: '', email: '', phone: '', isGuest: true });
-  const [serviceType, setServiceType] = useState('dine-in');
-  const [tableNumber, setTableNumber] = useState('12');
   const [isProcessing, setIsProcessing] = useState(false);
-  const [errors, setErrors] = useState({});
 
   const content = {
     en: { title: "Checkout", orderSummary: "Order Summary", customerInfo: "Customer Information", name: "Full Name", email: "Email Address", phone: "Phone Number", serviceType: "Service Type", dineIn: "Dine In", takeaway: "Takeaway", paymentMethod: "Payment Method", placeOrder: "Place Order", total: "Total", currency: "AUD" },

--- a/src/pages/qo_c006_payment.tsx
+++ b/src/pages/qo_c006_payment.tsx
@@ -1,13 +1,14 @@
-import React, { useState, useEffect } from 'react';
-import { CreditCard, Smartphone, QrCode, Lock, Shield, CheckCircle, AlertCircle, Eye, EyeOff, Fingerprint } from 'lucide-react';
+import { useState } from 'react';
+import type { JSX } from 'react';
+import { Lock, CheckCircle, AlertCircle } from 'lucide-react';
 import PageLayout from '../components/PageLayout';
 import { useLanguage } from '../contexts/LanguageContext';
 
+type PaymentStatusType = 'input' | 'processing' | 'success' | 'failed';
+
 const QOPayment = () => {
   const { language } = useLanguage();
-  const [paymentMethod, setPaymentMethod] = useState('card');
-  const [paymentStep, setPaymentStep] = useState('input');
-  const [cardDetails, setCardDetails] = useState({ number: '', expiry: '', cvv: '', name: '' });
+  const [paymentStep, setPaymentStep] = useState<PaymentStatusType>('input');
 
   const content = {
     en: { title: "Secure Payment", totalAmount: "Total Amount", payNow: "Pay Now", processing: "Processing...", paymentSuccessful: "Payment Successful!", paymentFailed: "Payment Failed", tryAgain: "Try Again", currency: "AUD" },
@@ -26,8 +27,8 @@ const QOPayment = () => {
     }, 2000);
   };
 
-  const PaymentStatus = ({ status }) => {
-    const statuses = {
+  const PaymentStatus = ({ status }: { status: PaymentStatusType }) => {
+    const statuses: Record<string, { icon: JSX.Element, title: string, color: string }> = {
       processing: { icon: <div className="w-8 h-8 border-4 border-blue-500 border-t-transparent rounded-full animate-spin"></div>, title: currentContent.processing, color: 'blue' },
       success: { icon: <CheckCircle className="w-12 h-12 text-green-500" />, title: currentContent.paymentSuccessful, color: 'green' },
       failed: { icon: <AlertCircle className="w-12 h-12 text-red-500" />, title: currentContent.paymentFailed, color: 'red' }

--- a/src/pages/qo_c007_order_status.tsx
+++ b/src/pages/qo_c007_order_status.tsx
@@ -1,22 +1,17 @@
-import React, { useState, useEffect } from 'react';
-import { Clock, CheckCircle, Phone, MessageSquare, Star, Receipt, Share, Bell, BellOff, ChefHat, Package } from 'lucide-react';
+import { useState, useEffect } from 'react';
+import { Clock, CheckCircle, Phone, MessageSquare, Bell, BellOff } from 'lucide-react';
 import PageLayout from '../components/PageLayout';
 import { useLanguage } from '../contexts/LanguageContext';
 
 const QOOrderStatus = () => {
   const { language } = useLanguage();
-  const [orderStatus, setOrderStatus] = useState('preparing');
-  const [estimatedTime, setEstimatedTime] = useState(12);
+  const [orderStatus] = useState('preparing');
+  const [estimatedTime] = useState(12);
   const [notificationsEnabled, setNotificationsEnabled] = useState(true);
 
   const content = {
     en: { title: "Order Status", orderConfirmed: "Confirmed", preparing: "Preparing", ready: "Ready", minutesLeft: "min left", orderTimeline: "Order Timeline", orderItems: "Order Items", callStaff: "Call Staff", sendMessage: "Send Message" },
     ko: { title: "주문 현황", orderConfirmed: "주문 확인", preparing: "조리 중", ready: "준비 완료", minutesLeft: "분 남음", orderTimeline: "주문 진행상황", orderItems: "주문 내역", callStaff: "직원 호출", sendMessage: "메시지" }
-  };
-
-  const orderData = {
-    items: [ { name: { en: 'Avocado Toast', ko: '아보카도 토스트' }, quantity: 2 }, { name: { en: 'Oat Milk Latte', ko: '오트밀크 라떼' }, quantity: 1 } ],
-    total: { AUD: 74.55, KRW: 107625 }
   };
 
   const currentContent = content[language];

--- a/src/pages/qo_c008_confirmation.tsx
+++ b/src/pages/qo_c008_confirmation.tsx
@@ -1,12 +1,9 @@
-import React, { useState, useEffect } from 'react';
-import { CheckCircle, Clock, QrCode, Home, RotateCcw } from 'lucide-react';
+import { CheckCircle, Home, RotateCcw } from 'lucide-react';
 import PageLayout from '../components/PageLayout';
 import { useLanguage } from '../contexts/LanguageContext';
 
 const QOOrderConfirmation = () => {
   const { language } = useLanguage();
-  const [showQRCode, setShowQRCode] = useState(false);
-  const [estimatedReadyTime, setEstimatedReadyTime] = useState(new Date(Date.now() + 15 * 60000));
 
   const content = {
     en: { title: "Order Confirmed!", thankYou: "Thank you for your order", orderNumber: "Order Number", confirmation: "Your order is confirmed", estimatedTime: "Estimated ready time", trackOrder: "Track Your Order", whatNext: "What's Next?", newOrder: "New Order" },
@@ -15,8 +12,6 @@ const QOOrderConfirmation = () => {
 
   const orderData = { orderNumber: "2024-001" };
   const currentContent = content[language];
-
-  const formatTime = (date) => date.toLocaleTimeString(language === 'ko' ? 'ko-KR' : 'en-AU', { hour: '2-digit', minute: '2-digit' });
 
   return (
     <PageLayout title={currentContent.title} backLink={undefined} removeMainPadding={true}>

--- a/src/pages/qo_s001_staff_login.tsx
+++ b/src/pages/qo_s001_staff_login.tsx
@@ -1,12 +1,11 @@
-import React, { useState } from 'react';
-import { User, Lock, Eye, EyeOff, Shield, Key, QrCode } from 'lucide-react';
+import { useState } from 'react';
+import { User, Lock } from 'lucide-react';
 import PageLayout from '../components/PageLayout';
 import { useLanguage } from '../contexts/LanguageContext';
 
 const QOStaffLogin = () => {
   const { language } = useLanguage();
   const [loginMethod, setLoginMethod] = useState('password');
-  const [credentials, setCredentials] = useState({ username: '', password: '' });
   const [isLoading, setIsLoading] = useState(false);
 
   const content = {

--- a/src/pages/qo_s002_dashboard.tsx
+++ b/src/pages/qo_s002_dashboard.tsx
@@ -1,12 +1,12 @@
-import React, { useState, useEffect } from 'react';
-import { Bell, Settings, LogOut, Clock, TrendingUp, Users, ShoppingBag, CheckCircle, Package } from 'lucide-react';
+import { useState, useEffect } from 'react';
+import { Bell, Settings, LogOut } from 'lucide-react';
 import PageLayout from '../components/PageLayout';
 import { useLanguage } from '../contexts/LanguageContext';
 
 const QOStaffDashboard = () => {
   const { language } = useLanguage();
-  const [currentTime, setCurrentTime] = useState(new Date());
-  const [isOnShift, setIsOnShift] = useState(true);
+  const [, setCurrentTime] = useState(new Date());
+  const [, setIsOnShift] = useState(true);
 
   const content = {
     en: { title: "Dashboard", welcome: "Welcome back", shiftStatus: "Shift Status", clockOut: "Clock Out", todayStats: "Today's Overview", totalOrders: "Total Orders", totalRevenue: "Revenue", quickActions: "Quick Actions", viewOrders: "View Orders" },

--- a/src/pages/qo_s003_order_management.tsx
+++ b/src/pages/qo_s003_order_management.tsx
@@ -1,12 +1,11 @@
-import React, { useState, useEffect } from 'react';
-import { Filter, Search, Clock, CheckCircle, RefreshCw, Bell } from 'lucide-react';
+import { useState } from 'react';
+import { Search, RefreshCw, Bell } from 'lucide-react';
 import PageLayout from '../components/PageLayout';
 import { useLanguage } from '../contexts/LanguageContext';
 
 const QOOrderManagement = () => {
   const { language } = useLanguage();
   const [selectedTab, setSelectedTab] = useState('all');
-  const [searchQuery, setSearchQuery] = useState('');
   const [soundEnabled, setSoundEnabled] = useState(true);
 
   const content = {
@@ -14,7 +13,7 @@ const QOOrderManagement = () => {
     ko: { title: "주문 관리", searchPlaceholder: "주문 검색...", tabs: { all: "전체", new: "신규", preparing: "조리중", ready: "준비완료" }, orderStatuses: { new: "신규", preparing: "조리중", ready: "준비완료", completed: "완료" }, orderInfo: { orderNumber: "주문번호 #", time: "시간", total: "총액" }, currency: "원" }
   };
 
-  const [orders, setOrders] = useState([
+  const [orders] = useState([
     { id: "128", status: "new", total: { AUD: 42.20, KRW: 62000 }, placedAt: new Date(Date.now() - 2 * 60000) },
     { id: "127", status: "preparing", total: { AUD: 29.80, KRW: 43500 }, placedAt: new Date(Date.now() - 18 * 60000) },
     { id: "126", status: "ready", total: { AUD: 28.50, KRW: 42000 }, placedAt: new Date(Date.now() - 25 * 60000) },

--- a/src/pages/qo_s004_kitchen_display.tsx
+++ b/src/pages/qo_s004_kitchen_display.tsx
@@ -1,6 +1,18 @@
-import React, { useState, useEffect } from 'react';
-import { Clock, AlertTriangle, CheckCircle, Flame, ChefHat, Timer, Bell, BellOff, Maximize, Settings, RefreshCw } from 'lucide-react';
+import { useState, useEffect } from 'react';
 import { useLanguage } from '../contexts/LanguageContext';
+
+interface OrderItem {
+  name: string;
+  qty: number;
+}
+
+interface Order {
+  id: string;
+  status: string;
+  placedAt: Date;
+  startedAt?: Date;
+  items: OrderItem[];
+}
 
 const QOKitchenDisplay = () => {
   const { language, setLanguage } = useLanguage();
@@ -11,7 +23,7 @@ const QOKitchenDisplay = () => {
     ko: { title: "주방 디스플레이", newOrders: "신규 주문", inProgress: "조리 중", readyToServe: "준비 완료", orderNumber: "주문 #", table: "테이블", time: "시간", elapsed: "경과", startCooking: "시작", markReady: "완료" }
   };
 
-  const [orders, setOrders] = useState([
+  const [orders, setOrders] = useState<Order[]>([
     { id: "128", status: "new", placedAt: new Date(Date.now() - 1 * 60000), items: [{ name: 'Avocado Toast', qty: 2 }] },
     { id: "129", status: "preparing", placedAt: new Date(Date.now() - 8 * 60000), startedAt: new Date(Date.now() - 5 * 60000), items: [{ name: 'Pancake Stack', qty: 1 }] },
     { id: "130", status: "preparing", placedAt: new Date(Date.now() - 18 * 60000), startedAt: new Date(Date.now() - 15 * 60000), items: [{ name: 'Breakfast Bowl', qty: 1 }] },
@@ -20,23 +32,23 @@ const QOKitchenDisplay = () => {
   const currentContent = content[language];
   useEffect(() => { const timer = setInterval(() => setCurrentTime(new Date()), 1000); return () => clearInterval(timer); }, []);
 
-  const getElapsedTime = (startTime) => Math.floor((currentTime.getTime() - (startTime?.getTime() || 0)) / (1000 * 60));
+  const getElapsedTime = (startTime: Date) => Math.floor((currentTime.getTime() - (startTime?.getTime() || 0)) / (1000 * 60));
 
-  const updateOrderStatus = (orderId, newStatus) => {
+  const updateOrderStatus = (orderId: string, newStatus: string) => {
     setOrders(orders.map(order => order.id === orderId ? { ...order, status: newStatus, startedAt: newStatus === 'preparing' ? new Date() : order.startedAt } : order));
   };
 
-  const OrderColumn = ({ title, orders, status, color }) => (
+  const OrderColumn = ({ title, orders, status, color }: { title: string, orders: Order[], status: string, color: string }) => (
     <div className={`bg-slate-800 rounded-lg p-4`}>
       <h2 className={`text-lg font-semibold text-${color}-400 mb-4`}>{title} ({orders.length})</h2>
       <div className="space-y-3">
-        {orders.map(order => (
+        {orders.map((order: Order) => (
           <div key={order.id} className={`bg-slate-700 rounded-lg p-4 border-l-4 border-${color}-500`}>
             <div className="flex justify-between items-center mb-2">
               <span className="font-bold text-lg">#{order.id}</span>
               <span className="text-sm text-slate-400">{getElapsedTime(order.placedAt)} min ago</span>
             </div>
-            {order.items.map((item, i) => <div key={i} className="font-medium">{item.name} × {item.qty}</div>)}
+            {order.items.map((item: OrderItem, i: number) => <div key={i} className="font-medium">{item.name} × {item.qty}</div>)}
             <button onClick={() => updateOrderStatus(order.id, status === 'new' ? 'preparing' : 'ready')} className={`w-full mt-3 bg-${color}-600 hover:bg-${color}-700 text-white py-2 rounded font-semibold`}>
               {status === 'new' ? currentContent.startCooking : currentContent.markReady}
             </button>

--- a/src/pages/qo_s005_menu_management.tsx
+++ b/src/pages/qo_s005_menu_management.tsx
@@ -1,11 +1,11 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Plus, BarChart3, Search, Eye, EyeOff } from 'lucide-react';
 import PageLayout from '../components/PageLayout';
 import { useLanguage } from '../contexts/LanguageContext';
 
 const QOMenuManagement = () => {
   const { language } = useLanguage();
-  const [searchQuery, setSearchQuery] = useState('');
+  const [searchQuery] = useState('');
   const [selectedCategory, setSelectedCategory] = useState('all');
 
   const content = {
@@ -25,7 +25,7 @@ const QOMenuManagement = () => {
 
   const filteredItems = menuItems.filter(item => (selectedCategory === 'all' || item.category === selectedCategory) && (searchQuery === '' || item.name[language].toLowerCase().includes(searchQuery.toLowerCase())));
 
-  const toggleAvailability = (id) => {
+  const toggleAvailability = (id: number) => {
     setMenuItems(items => items.map(item => item.id === id ? { ...item, availability: item.availability === 'available' ? 'unavailable' : 'available' } : item));
   };
 

--- a/src/pages/qo_s006_table_management.tsx
+++ b/src/pages/qo_s006_table_management.tsx
@@ -1,18 +1,28 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { QrCode, Users, Plus } from 'lucide-react';
 import PageLayout from '../components/PageLayout';
 import { useLanguage } from '../contexts/LanguageContext';
+
+type TableStatus = 'available' | 'occupied' | 'reserved';
+
+interface Table {
+  id: number;
+  tableNumber: string;
+  capacity: number;
+  area: string;
+  status: TableStatus;
+}
 
 const QOTableManagement = () => {
   const { language } = useLanguage();
   const [selectedArea, setSelectedArea] = useState('all');
 
   const content = {
-    en: { title: "Table Management", areas: { all: "All", indoor: "Indoor", outdoor: "Outdoor" }, tableStatus: { available: "Available", occupied: "Occupied", reserved: "Reserved" }, people: "people" },
-    ko: { title: "테이블 관리", areas: { all: "전체", indoor: "실내", outdoor: "야외" }, tableStatus: { available: "이용 가능", occupied: "사용 중", reserved: "예약됨" }, people: "명" }
+    en: { title: "Table Management", areas: { all: "All", indoor: "Indoor", outdoor: "Outdoor" }, tableStatus: { available: "Available", occupied: "Occupied", reserved: "Reserved" }, people: "people", actions: { addTable: "Add Table" } },
+    ko: { title: "테이블 관리", areas: { all: "전체", indoor: "실내", outdoor: "야외" }, tableStatus: { available: "이용 가능", occupied: "사용 중", reserved: "예약됨" }, people: "명", actions: { addTable: "테이블 추가" } }
   };
 
-  const [tables, setTables] = useState([
+  const [tables] = useState<Table[]>([
     { id: 1, tableNumber: "1", capacity: 2, area: "indoor", status: "occupied" },
     { id: 2, tableNumber: "2", capacity: 4, area: "indoor", status: "available" },
     { id: 5, tableNumber: "5", capacity: 4, area: "outdoor", status: "occupied" },
@@ -22,7 +32,7 @@ const QOTableManagement = () => {
   const currentContent = content[language];
   const filteredTables = tables.filter(table => selectedArea === 'all' || table.area === selectedArea);
 
-  const getStatusColor = (status) => {
+  const getStatusColor = (status: TableStatus) => {
     switch (status) {
       case 'available': return 'bg-green-100 text-green-800 border-green-200';
       case 'occupied': return 'bg-blue-100 text-blue-800 border-blue-200';
@@ -34,7 +44,7 @@ const QOTableManagement = () => {
   const HeaderActions = () => (
     <button className="flex items-center space-x-2 px-3 py-2 bg-blue-600 text-white rounded-lg text-sm font-medium">
       <Plus className="w-4 h-4" />
-      <span>{content.en.actions?.addTable || 'Add Table'}</span>
+      <span>{currentContent.actions.addTable}</span>
     </button>
   );
 

--- a/src/pages/qo_s007_customer_service.tsx
+++ b/src/pages/qo_s007_customer_service.tsx
@@ -1,7 +1,18 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Search, Bell, BellOff, MessageSquare, ThumbsUp } from 'lucide-react';
 import PageLayout from '../components/PageLayout';
 import { useLanguage } from '../contexts/LanguageContext';
+
+type RequestStatus = 'pending' | 'resolved';
+type RequestType = 'assistance' | 'complaint' | 'compliment';
+
+interface Request {
+  id: number;
+  customer: string;
+  type: RequestType;
+  status: RequestStatus;
+  title: string;
+}
 
 const QOCustomerService = () => {
   const { language } = useLanguage();
@@ -13,7 +24,7 @@ const QOCustomerService = () => {
     ko: { title: "고객 서비스", searchPlaceholder: "요청 검색...", filters: { all: "전체", pending: "대기중", resolved: "해결됨" }, requestTypes: { assistance: "도움", complaint: "불만" }, status: { pending: "대기중", resolved: "해결됨" } }
   };
 
-  const [requests, setRequests] = useState([
+  const [requests] = useState<Request[]>([
     { id: 1, customer: "John Smith", type: "assistance", status: "pending", title: "Need extra napkins" },
     { id: 2, customer: "Sarah Johnson", type: "complaint", status: "pending", title: "Food is taking too long" },
     { id: 3, customer: "Mike Chen", type: "compliment", status: "resolved", title: "Excellent service!" },
@@ -22,7 +33,7 @@ const QOCustomerService = () => {
   const currentContent = content[language];
   const filteredRequests = requests.filter(req => selectedFilter === 'all' || req.status === selectedFilter);
 
-  const getTypeIcon = (type) => {
+  const getTypeIcon = (type: RequestType) => {
     if (type === 'compliment') return <ThumbsUp className="w-4 h-4 text-green-600" />;
     return <MessageSquare className="w-4 h-4 text-blue-600" />;
   };
@@ -64,7 +75,7 @@ const QOCustomerService = () => {
                   </div>
                 </div>
                 <span className={`px-2 py-1 text-xs font-medium rounded-full ${request.status === 'pending' ? 'bg-orange-100 text-orange-800' : 'bg-green-100 text-green-800'}`}>
-                  {currentContent.status[request.status]}
+                  {currentContent.status[request.status as RequestStatus]}
                 </span>
               </div>
             </div>

--- a/src/pages/qo_s008_staff_analytics.tsx
+++ b/src/pages/qo_s008_staff_analytics.tsx
@@ -1,18 +1,33 @@
-import React, { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { TrendingUp, TrendingDown, Activity } from 'lucide-react';
 import PageLayout from '../components/PageLayout';
 import { useLanguage } from '../contexts/LanguageContext';
 
+type Period = 'today' | 'week' | 'month';
+
+interface Trend {
+  ordersProcessed: number;
+  avgOrderTime: number;
+  customerRating: number;
+}
+
+interface Metrics {
+  ordersProcessed: number;
+  avgOrderTime: number;
+  customerRating: number;
+  trend: Trend;
+}
+
 const QOStaffAnalytics = () => {
   const { language } = useLanguage();
-  const [selectedPeriod, setSelectedPeriod] = useState('today');
+  const [selectedPeriod, setSelectedPeriod] = useState<Period>('today');
 
   const content = {
     en: { title: "Staff Analytics", periods: { today: "Today", week: "This Week", month: "This Month" }, metrics: { ordersProcessed: "Orders Processed", avgOrderTime: "Avg Order Time", customerRating: "Customer Rating" }, vs: "vs last period" },
     ko: { title: "직원 분석", periods: { today: "오늘", week: "이번 주", month: "이번 달" }, metrics: { ordersProcessed: "처리 주문", avgOrderTime: "평균 주문시간", customerRating: "고객 평점" }, vs: "지난 기간 대비" }
   };
 
-  const personalMetrics = {
+  const personalMetrics: Record<Period, Metrics> = {
     today: { ordersProcessed: 23, avgOrderTime: 12.5, customerRating: 4.8, trend: { ordersProcessed: 8.7, avgOrderTime: -5.2, customerRating: 2.1 } },
     week: { ordersProcessed: 147, avgOrderTime: 13.2, customerRating: 4.7, trend: { ordersProcessed: 2.1, avgOrderTime: 1.5, customerRating: -1.1 } },
     month: { ordersProcessed: 612, avgOrderTime: 13.8, customerRating: 4.6, trend: { ordersProcessed: 5.2, avgOrderTime: 0.5, customerRating: 0.5 } }
@@ -21,7 +36,7 @@ const QOStaffAnalytics = () => {
   const currentContent = content[language];
   const currentMetrics = personalMetrics[selectedPeriod];
 
-  const getTrendIcon = (trend) => {
+  const getTrendIcon = (trend: number) => {
     if (trend > 0) return <TrendingUp className="w-4 h-4 text-green-600" />;
     if (trend < 0) return <TrendingDown className="w-4 h-4 text-red-600" />;
     return <Activity className="w-4 h-4 text-slate-600" />;
@@ -34,7 +49,7 @@ const QOStaffAnalytics = () => {
         <div className="bg-white rounded-xl p-2">
           <div className="flex space-x-1">
             {Object.entries(currentContent.periods).map(([key, label]) => (
-              <button key={key} onClick={() => setSelectedPeriod(key)} className={`flex-1 py-2 rounded-lg text-sm font-medium ${selectedPeriod === key ? 'bg-blue-600 text-white' : 'text-slate-600 hover:bg-slate-100'}`}>
+              <button key={key} onClick={() => setSelectedPeriod(key as Period)} className={`flex-1 py-2 rounded-lg text-sm font-medium ${selectedPeriod === key ? 'bg-blue-600 text-white' : 'text-slate-600 hover:bg-slate-100'}`}>
                 {label}
               </button>
             ))}


### PR DESCRIPTION
This commit introduces a new root page that serves as a directory to all the customer and staff-facing sample pages. The new page is designed to be simple and user-friendly, using Tailwind CSS for styling. It includes the requested announcement about the upcoming launch of 'viatable'.

The previous implementation of the home page, which was a detailed showcase, has been preserved in `src/pages/HomePage_showcase.tsx`.

Additionally, this commit includes a significant amount of refactoring across the entire codebase to fix a large number of TypeScript errors that were preventing the project from building successfully. These changes include removing unused variables and imports, and adding explicit types where needed.