### PR TITLE
feat: Finalize landing page and sample routes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,16 +40,16 @@ function App() {
     <LanguageProvider>
       <BrowserRouter>
         <Routes>
-          <Route path="/" element={<FramedPage><VTL001 /></FramedPage>} />
+          <Route path="/" element={<VTL001 />} />
           <Route path="/samples" element={<HomePage />} />
 
           {/* Viatable Sample Pages */}
-          <Route path="/vt-l001" element={<FramedPage><VTL001 /></FramedPage>} />
-          <Route path="/vt-l002" element={<FramedPage><VTL002 /></FramedPage>} />
-          <Route path="/vt-l003" element={<FramedPage><VTL003 /></FramedPage>} />
-          <Route path="/vt-l004" element={<FramedPage><VTL004 /></FramedPage>} />
-          <Route path="/vt-l005" element={<FramedPage><VTL005 /></FramedPage>} />
-          <Route path="/vt-l017" element={<FramedPage><VTL017 /></FramedPage>} />
+          <Route path="/vt-l001" element={<VTL001 />} />
+          <Route path="/vt-l002" element={<VTL002 />} />
+          <Route path="/vt-l003" element={<VTL003 />} />
+          <Route path="/vt-l004" element={<VTL004 />} />
+          <Route path="/vt-l005" element={<VTL005 />} />
+          <Route path="/vt-l017" element={<VTL017 />} />
 
           {/* Customer Pages */}
           <Route path="/qo-c-001" element={<FramedPage><QoC001 /></FramedPage>} />

--- a/src/pages/vt-l001-viatable_landing_page.tsx
+++ b/src/pages/vt-l001-viatable_landing_page.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
 import { 
   QrCode, Smartphone, TrendingUp, Globe, Users, ShoppingCart,
   Check, Star, ArrowRight, Play, Menu, X, MapPin, Clock,
@@ -602,6 +603,9 @@ const ViableTableLandingPage = () => {
           </div>
           
           <div className="border-t border-gray-800 mt-12 pt-8 text-center text-gray-400">
+            <div className="mb-4">
+              <Link to="/samples" className="text-purple-400 hover:text-white transition-colors">View Component Samples</Link>
+            </div>
             <p>&copy; 2024 VIATABLE. All rights reserved. Making every table viable.</p>
           </div>
         </div>


### PR DESCRIPTION
This commit finalizes the landing page implementation based on user feedback.

- The `vt-l001` component is set as the root landing page.
- The iPhone frame has been removed from all `vt-l` series pages.
- The original list of customer and staff pages is now available at the `/samples` route.
- A link to the `/samples` page has been added to the footer of the `vt-l001` landing page.

This completes all requested changes for the new landing page structure.