### PR TITLE
feat: Add admin sample pages with tablet frame

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,9 +2,16 @@ import React from 'react';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { LanguageProvider } from './contexts/LanguageContext';
 import IphoneFrame from './components/iPhoneFrame';
+import TabletFrame from './components/TabletFrame';
 
 // Import all page components
 import HomePage from './pages/HomePage';
+import QoA001 from './pages/samples/admin/qo-a001-admin_dashboard';
+import QoA002 from './pages/samples/admin/qo-a002-multi_location_management';
+import QoA003 from './pages/samples/admin/qo-a003-global_menu_management';
+import QoA004 from './pages/samples/admin/qo-a004-staff_management';
+import QoA005 from './pages/samples/admin/qo-a005-analytics_reports';
+import QoA006 from './pages/samples/admin/qo-a006-system_settings_fixed';
 import QoC001 from './pages/qo_c001_landing';
 import QoC002 from './pages/qo_c002_menu';
 import QoC003 from './pages/qo_c003_item_details';
@@ -33,6 +40,11 @@ import VTL017 from './pages/vt-l017-viatable_login_new';
 // A wrapper component to apply the iPhone frame to pages
 const FramedPage = ({ children }: { children: React.ReactNode }) => (
   <IphoneFrame>{children}</IphoneFrame>
+);
+
+// A wrapper component to apply the tablet frame to pages
+const TabletFramedPage = ({ children }: { children: React.ReactNode }) => (
+  <TabletFrame>{children}</TabletFrame>
 );
 
 function App() {
@@ -70,6 +82,14 @@ function App() {
           <Route path="/qo-s-006" element={<FramedPage><QoS006 /></FramedPage>} />
           <Route path="/qo-s-007" element={<FramedPage><QoS007 /></FramedPage>} />
           <Route path="/qo-s-008" element={<FramedPage><QoS008 /></FramedPage>} />
+
+          {/* Admin Pages */}
+          <Route path="/qo-a-001" element={<TabletFramedPage><QoA001 /></TabletFramedPage>} />
+          <Route path="/qo-a-002" element={<TabletFramedPage><QoA002 /></TabletFramedPage>} />
+          <Route path="/qo-a-003" element={<TabletFramedPage><QoA003 /></TabletFramedPage>} />
+          <Route path="/qo-a-004" element={<TabletFramedPage><QoA004 /></TabletFramedPage>} />
+          <Route path="/qo-a-005" element={<TabletFramedPage><QoA005 /></TabletFramedPage>} />
+          <Route path="/qo-a-006" element={<TabletFramedPage><QoA006 /></TabletFramedPage>} />
         </Routes>
       </BrowserRouter>
     </LanguageProvider>

--- a/src/components/TabletFrame.tsx
+++ b/src/components/TabletFrame.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+interface TabletFrameProps {
+  children: React.ReactNode;
+}
+
+const TabletFrame: React.FC<TabletFrameProps> = ({ children }) => {
+  const backgroundClasses = "flex min-h-screen w-full items-center justify-center bg-gray-100 p-4 sm:p-8";
+  // iPad-like dimensions and styling
+  const frameClasses = "relative mx-auto h-[1024px] w-[768px] rounded-[36px] border-[16px] border-black bg-black shadow-2xl";
+  const screenClasses = "relative h-full w-full overflow-hidden rounded-[20px] bg-white";
+
+  return (
+    // Background container
+    <div className={backgroundClasses}>
+      {/* Tablet Frame */}
+      <div className={frameClasses}>
+        {/* Front-facing camera */}
+        <div className="absolute left-1/2 top-[6px] z-10 h-[8px] w-[8px] -translate-x-1/2 rounded-full bg-gray-800"></div>
+
+        {/* Screen */}
+        <div className={screenClasses}>
+          <div className="h-full w-full overflow-y-auto">
+            {children}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TabletFrame;

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,6 +1,15 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { ExternalLink, Users, Briefcase } from 'lucide-react';
+import { ExternalLink, Users, Briefcase, Shield } from 'lucide-react';
+
+const adminPages = [
+  { href: '/qo-a-001', title: 'QO-A001: Admin Dashboard' },
+  { href: '/qo-a-002', title: 'QO-A002: Multi-Location Management' },
+  { href: '/qo-a-003', title: 'QO-A003: Global Menu Management' },
+  { href: '/qo-a-004', title: 'QO-A004: Staff Management' },
+  { href: '/qo-a-005', title: 'QO-A005: Analytics & Reports' },
+  { href: '/qo-a-006', title: 'QO-A006: System Settings' },
+];
 
 const customerPages = [
   { href: '/qo-c-001', title: 'QO-C001: Landing Page' },
@@ -52,7 +61,20 @@ const HomePage: React.FC = () => {
           </p>
         </div>
 
-        <div className="mt-16 grid gap-12 md:grid-cols-2">
+        <div className="mt-16 grid gap-8 md:grid-cols-2 lg:grid-cols-3">
+          {/* Admin Pages */}
+          <div className="bg-white p-6 rounded-xl shadow-md">
+            <h2 className="text-2xl font-bold text-gray-800 mb-4 flex items-center">
+              <Shield className="w-7 h-7 mr-3 text-red-500" />
+              Admin Pages
+            </h2>
+            <ul>
+              {adminPages.map((page) => (
+                <PageLink key={page.href} {...page} />
+              ))}
+            </ul>
+          </div>
+
           {/* Customer Pages */}
           <div className="bg-white p-6 rounded-xl shadow-md">
             <h2 className="text-2xl font-bold text-gray-800 mb-4 flex items-center">

--- a/src/pages/samples/admin/qo-a001-admin_dashboard.tsx
+++ b/src/pages/samples/admin/qo-a001-admin_dashboard.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
 import { 
-  BarChart3, Users, ShoppingCart, DollarSign, TrendingUp, TrendingDown,
-  Bell, Settings, Search, Calendar, ChevronDown, Store, Globe,
-  ArrowUpRight, ArrowDownRight, Clock, Star, AlertTriangle
+  BarChart3, ShoppingCart, DollarSign,
+  Bell, Settings, Search, Store, Globe,
+  ArrowUpRight, ArrowDownRight, Star, AlertTriangle
 } from 'lucide-react';
 
 const AdminDashboard = () => {

--- a/src/pages/samples/admin/qo-a002-multi_location_management.tsx
+++ b/src/pages/samples/admin/qo-a002-multi_location_management.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
 import { 
-  MapPin, Store, Plus, Edit, Trash2, Users, Clock, Wifi, Power,
-  Search, Filter, MoreVertical, Eye, Settings, TrendingUp, TrendingDown,
-  CheckCircle, XCircle, AlertTriangle, Calendar, Globe, Phone, Mail
+  MapPin, Store, Plus, Wifi, Power,
+  Search, MoreVertical, Eye, Settings, TrendingUp, TrendingDown,
+  CheckCircle, XCircle, AlertTriangle
 } from 'lucide-react';
 
 const MultiLocationManagement = () => {
@@ -10,8 +10,7 @@ const MultiLocationManagement = () => {
   const [filterStatus, setFilterStatus] = useState('all');
   const [filterRegion, setFilterRegion] = useState('all');
   const [searchQuery, setSearchQuery] = useState('');
-  const [showAddModal, setShowAddModal] = useState(false);
-  const [selectedLocation, setSelectedLocation] = useState(null);
+  const [, setShowAddModal] = useState(false);
 
   // Mock data for locations
   const locations = [

--- a/src/pages/samples/admin/qo-a003-global_menu_management.tsx
+++ b/src/pages/samples/admin/qo-a003-global_menu_management.tsx
@@ -1,9 +1,9 @@
 import React, { useState } from 'react';
 import { 
-  Plus, Search, Filter, Edit, Trash2, Copy, Eye, EyeOff, 
-  Upload, Download, Globe, Store, Clock, DollarSign,
-  ChefHat, Leaf, Zap, Star, AlertTriangle, CheckCircle,
-  MoreVertical, Image, Tag, Users, TrendingUp, Camera
+  Plus, Search, Edit, Copy, Eye, EyeOff,
+  Upload, Download, Clock,
+  ChefHat, Star, AlertTriangle, CheckCircle,
+  MoreVertical, Users, TrendingUp
 } from 'lucide-react';
 
 const GlobalMenuManagement = () => {
@@ -12,7 +12,7 @@ const GlobalMenuManagement = () => {
   const [selectedStatus, setSelectedStatus] = useState('all');
   const [searchQuery, setSearchQuery] = useState('');
   const [viewMode, setViewMode] = useState('grid');
-  const [showAddModal, setShowAddModal] = useState(false);
+  const [, setShowAddModal] = useState(false);
 
   // Mock data for menu items
   const menuItems = [
@@ -187,7 +187,7 @@ const GlobalMenuManagement = () => {
   });
 
   const MenuCard = ({ item }) => {
-    const availableLocations = Object.entries(item.availability).filter(([_, available]) => available).length;
+    const availableLocations = Object.entries(item.availability).filter(([, available]) => available).length;
     
     return (
       <div className="bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden hover:shadow-md transition-shadow">
@@ -514,7 +514,7 @@ const GlobalMenuManagement = () => {
                       </div>
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                      {Object.entries(item.availability).filter(([_, available]) => available).length}/5 locations
+                      {Object.entries(item.availability).filter(([, available]) => available).length}/5 locations
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
                       <div className="flex items-center space-x-1">

--- a/src/pages/samples/admin/qo-a004-staff_management.tsx
+++ b/src/pages/samples/admin/qo-a004-staff_management.tsx
@@ -1,9 +1,9 @@
 import React, { useState } from 'react';
 import { 
-  Users, Plus, Search, Filter, Edit, Trash2, Eye, EyeOff, 
-  Shield, Crown, User, Clock, Phone, Mail, MapPin,
-  Calendar, Award, TrendingUp, AlertTriangle, CheckCircle,
-  MoreVertical, Settings, Key, UserPlus, Download, Upload
+  Users, Search, Eye, EyeOff,
+  Shield, Crown, User, Clock,
+  TrendingUp, AlertTriangle, CheckCircle,
+  MoreVertical, Key, UserPlus, Download, Upload
 } from 'lucide-react';
 
 const StaffManagement = () => {
@@ -12,7 +12,7 @@ const StaffManagement = () => {
   const [selectedStatus, setSelectedStatus] = useState('all');
   const [searchQuery, setSearchQuery] = useState('');
   const [viewMode, setViewMode] = useState('grid');
-  const [showAddModal, setShowAddModal] = useState(false);
+  const [, setShowAddModal] = useState(false);
 
   // Mock data for staff members
   const staffMembers = [

--- a/src/pages/samples/admin/qo-a005-analytics_reports.tsx
+++ b/src/pages/samples/admin/qo-a005-analytics_reports.tsx
@@ -1,10 +1,10 @@
 import React, { useState } from 'react';
 import { 
-  BarChart3, TrendingUp, TrendingDown, DollarSign, Users, Clock,
-  Download, Calendar, Filter, RefreshCw, Eye, Share, 
-  PieChart, Activity, Target, Award, MapPin, ShoppingCart,
-  Star, Coffee, Utensils, CreditCard, Globe, ArrowUpRight,
-  ArrowDownRight, AlertTriangle, CheckCircle, Zap
+  BarChart3, TrendingUp, DollarSign, Users, Clock,
+  Download, RefreshCw, Share,
+  Activity, Target, Award, MapPin, ShoppingCart,
+  Star, Utensils, ArrowUpRight,
+  ArrowDownRight, AlertTriangle
 } from 'lucide-react';
 
 const AnalyticsReports = () => {

--- a/src/pages/samples/admin/qo-a006-system_settings_fixed.tsx
+++ b/src/pages/samples/admin/qo-a006-system_settings_fixed.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
 import { 
-  Settings, Globe, Shield, CreditCard, Bell, 
+  Settings, Shield, CreditCard, Bell,
   Save, RefreshCw, Upload, Download, 
-  MapPin, Zap, Palette, Info
+  Info
 } from 'lucide-react';
 
 const SystemSettings = () => {


### PR DESCRIPTION
- Create a new TabletFrame component to display pages in an iPad-like frame.
- Move the six administrator-focused sample pages (qo-a001 to qo-a006) into a new `src/pages/samples/admin` directory.
- Update the main application router in `App.tsx` to include routes for the new admin pages, wrapping them with the TabletFrame.
- Add a new "Admin Pages" section to the main sample page (`HomePage.tsx`) with links to the new pages.
- Clean up unused icon imports and state variables in the new admin page components to resolve linting errors.