### PR TITLE
refactor: Change tablet frame to landscape orientation

### DIFF
--- a/src/components/TabletFrame.tsx
+++ b/src/components/TabletFrame.tsx
@@ -6,8 +6,8 @@ interface TabletFrameProps {
 
 const TabletFrame: React.FC<TabletFrameProps> = ({ children }) => {
   const backgroundClasses = "flex min-h-screen w-full items-center justify-center bg-gray-100 p-4 sm:p-8";
-  // iPad-like dimensions and styling
-  const frameClasses = "relative mx-auto h-[1024px] w-[768px] rounded-[36px] border-[16px] border-black bg-black shadow-2xl";
+  // iPad-like dimensions and styling - landscape
+  const frameClasses = "relative mx-auto h-[768px] w-[1024px] rounded-[36px] border-[16px] border-black bg-black shadow-2xl";
   const screenClasses = "relative h-full w-full overflow-hidden rounded-[20px] bg-white";
 
   return (
@@ -16,7 +16,7 @@ const TabletFrame: React.FC<TabletFrameProps> = ({ children }) => {
       {/* Tablet Frame */}
       <div className={frameClasses}>
         {/* Front-facing camera */}
-        <div className="absolute left-1/2 top-[6px] z-10 h-[8px] w-[8px] -translate-x-1/2 rounded-full bg-gray-800"></div>
+        <div className="absolute top-1/2 left-[6px] z-10 h-[8px] w-[8px] -translate-y-1/2 rounded-full bg-gray-800"></div>
 
         {/* Screen */}
         <div className={screenClasses}>


### PR DESCRIPTION
Based on user feedback, this commit modifies the `TabletFrame.tsx` component to display in a landscape (horizontal) orientation.

- Swapped the height and width values of the frame.
- Adjusted the position of the front-facing camera to the side to match the new orientation.