### PR TITLE
feat: Redesign samples page and add nav link

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
-import { ExternalLink, Users, Briefcase, Shield } from 'lucide-react';
+import { ExternalLink, Users, Shield, UserCheck } from 'lucide-react';
 
 const adminPages = [
   { href: '/qo-a-001', title: 'QO-A001: Admin Dashboard' },
@@ -37,69 +37,74 @@ const PageLink: React.FC<{ href: string; title: string }> = ({ href, title }) =>
   <li className="mb-2">
     <Link
       to={href}
-      className="flex items-center justify-between p-3 bg-gray-50 hover:bg-gray-100 rounded-lg transition-colors duration-200"
+      target="_blank"
+      rel="noopener noreferrer"
+      className="flex items-center justify-between p-4 bg-gray-50 hover:bg-gray-100 rounded-lg transition-colors duration-200 group"
     >
-      <span className="font-medium text-gray-700">{title}</span>
-      <ExternalLink className="w-5 h-5 text-gray-400" />
+      <span className="font-medium text-gray-700 group-hover:text-purple-600">{title}</span>
+      <ExternalLink className="w-5 h-5 text-gray-400 group-hover:text-purple-600 transition-colors" />
     </Link>
   </li>
 );
 
+const TABS = [
+  { id: 'admin', name: 'Administrator', icon: Shield, pages: adminPages },
+  { id: 'customer', name: 'Customer Journey', icon: Users, pages: customerPages },
+  { id: 'staff', name: 'Staff Interface', icon: UserCheck, pages: staffPages },
+];
+
 const HomePage: React.FC = () => {
+  const [activeTab, setActiveTab] = useState('admin');
+
+  const activeTabData = TABS.find(tab => tab.id === activeTab);
+
   return (
-    <div className="bg-gray-50 min-h-screen">
-      <div className="max-w-4xl mx-auto py-12 px-4 sm:px-6 lg:px-8">
-        <div className="text-center">
-          <h1 className="text-4xl font-extrabold text-gray-900 sm:text-5xl md:text-6xl">
-            viatable
+    <div className="bg-white min-h-screen">
+      <div className="bg-gray-900 text-white">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16 text-center">
+          <h1 className="text-4xl font-extrabold sm:text-5xl md:text-6xl bg-gradient-to-r from-purple-400 to-pink-500 bg-clip-text text-transparent">
+            Interactive Product Showcase
           </h1>
-          <p className="mt-3 max-w-md mx-auto text-base text-gray-500 sm:text-lg md:mt-5 md:text-xl md:max-w-3xl">
-            viatable will be launched in December. Simultaneous service open in Korea/Australia.
-          </p>
-          <p className="mt-3 max-w-md mx-auto text-base text-gray-500 sm:text-lg md:mt-5 md:text-xl md:max-w-3xl">
-            (viatable 12월에 오픈 예정. 한국/호주 동시 서비스 오픈.)
+          <p className="mt-4 max-w-2xl mx-auto text-xl text-gray-300">
+            Explore the core user journeys of the VIATABLE platform. Click on any page to open a live, interactive demo in a new tab.
           </p>
         </div>
+      </div>
 
-        <div className="mt-16 grid gap-8 md:grid-cols-2 lg:grid-cols-3">
-          {/* Admin Pages */}
-          <div className="bg-white p-6 rounded-xl shadow-md">
-            <h2 className="text-2xl font-bold text-gray-800 mb-4 flex items-center">
-              <Shield className="w-7 h-7 mr-3 text-red-500" />
-              Admin Pages
-            </h2>
-            <ul>
-              {adminPages.map((page) => (
-                <PageLink key={page.href} {...page} />
-              ))}
-            </ul>
-          </div>
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        <div className="border-b border-gray-200 mb-8">
+          <nav className="-mb-px flex space-x-6" aria-label="Tabs">
+            {TABS.map((tab) => (
+              <button
+                key={tab.id}
+                onClick={() => setActiveTab(tab.id)}
+                className={`flex items-center space-x-2 whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm transition-colors ${
+                  activeTab === tab.id
+                    ? 'border-purple-500 text-purple-600'
+                    : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
+                }`}
+              >
+                <tab.icon className="w-5 h-5" />
+                <span>{tab.name}</span>
+              </button>
+            ))}
+          </nav>
+        </div>
 
-          {/* Customer Pages */}
-          <div className="bg-white p-6 rounded-xl shadow-md">
-            <h2 className="text-2xl font-bold text-gray-800 mb-4 flex items-center">
-              <Users className="w-7 h-7 mr-3 text-indigo-500" />
-              Customer Pages
-            </h2>
-            <ul>
-              {customerPages.map((page) => (
-                <PageLink key={page.href} {...page} />
-              ))}
-            </ul>
-          </div>
-
-          {/* Staff Pages */}
-          <div className="bg-white p-6 rounded-xl shadow-md">
-            <h2 className="text-2xl font-bold text-gray-800 mb-4 flex items-center">
-              <Briefcase className="w-7 h-7 mr-3 text-green-500" />
-              Staff Pages
-            </h2>
-            <ul>
-              {staffPages.map((page) => (
-                <PageLink key={page.href} {...page} />
-              ))}
-            </ul>
-          </div>
+        <div>
+          {activeTabData && (
+            <div className="bg-white p-6 rounded-xl shadow-lg border border-gray-100">
+              <h2 className="text-2xl font-bold text-gray-800 mb-4 flex items-center">
+                <activeTabData.icon className="w-7 h-7 mr-3 text-purple-500" />
+                {activeTabData.name}
+              </h2>
+              <ul className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                {activeTabData.pages.map((page) => (
+                  <PageLink key={page.href} {...page} />
+                ))}
+              </ul>
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/src/pages/vt-l001-viatable_landing_page.tsx
+++ b/src/pages/vt-l001-viatable_landing_page.tsx
@@ -19,6 +19,7 @@ const ViableTableLandingPage = () => {
         features: 'Features',
         pricing: 'Pricing',
         demo: 'Demo',
+        showcase: 'Showcase',
         contact: 'Contact',
         login: 'Login',
         signup: 'Get Started'
@@ -172,6 +173,7 @@ const ViableTableLandingPage = () => {
         features: '기능',
         pricing: '요금제',
         demo: '데모',
+        showcase: '쇼케이스',
         contact: '문의',
         login: '로그인',
         signup: '시작하기'
@@ -302,6 +304,7 @@ const ViableTableLandingPage = () => {
               <a href="#features" className="text-gray-600 hover:text-gray-900 transition-colors">{currentContent.nav.features}</a>
               <a href="#pricing" className="text-gray-600 hover:text-gray-900 transition-colors">{currentContent.nav.pricing}</a>
               <a href="#demo" className="text-gray-600 hover:text-gray-900 transition-colors">{currentContent.nav.demo}</a>
+              <Link to="/samples" className="text-gray-600 hover:text-gray-900 transition-colors">{currentContent.nav.showcase}</Link>
               <a href="#contact" className="text-gray-600 hover:text-gray-900 transition-colors">{currentContent.nav.contact}</a>
               
               <div className="flex items-center space-x-2">


### PR DESCRIPTION
This commit introduces a significant redesign of the samples showcase page (`/samples`) and integrates it into the main site navigation.

- Redesigned the `HomePage.tsx` component to feature a professional layout with a new title, description, and a tabbed interface.
- The tabs organize the sample pages into "Administrator," "Customer," and "Staff" user journeys for clarity.
- Added a "Showcase" link to the main navigation bar in `vt-l001-viatable_landing_page.tsx` to make the samples page discoverable.
- Added Korean translations for the new navigation link.
- Cleaned up unused icon imports in the redesigned `HomePage.tsx`.