### PR TITLE
feat: Create immersive showcase with guided navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { LanguageProvider } from './contexts/LanguageContext';
-import IphoneFrame from './components/iPhoneFrame';
-import TabletFrame from './components/TabletFrame';
+import ShowcasePageLayout from './components/ShowcasePageLayout';
 
 // Import all page components
 import HomePage from './pages/HomePage';
@@ -37,15 +36,38 @@ import VTL004 from './pages/vt-l004-viatable_demo_trial';
 import VTL005 from './pages/vt-l005-viatable_features_new';
 import VTL017 from './pages/vt-l017-viatable_login_new';
 
-// A wrapper component to apply the iPhone frame to pages
-const FramedPage = ({ children }: { children: React.ReactNode }) => (
-  <IphoneFrame>{children}</IphoneFrame>
-);
+const customerJourney = [
+  { path: '/qo-c-001', component: QoC001, title: 'QO-C001: Landing Page' },
+  { path: '/qo-c-002', component: QoC002, title: 'QO-C002: Menu Catalog' },
+  { path: '/qo-c-003', component: QoC003, title: 'QO-C003: Item Details' },
+  { path: '/qo-c-004', component: QoC004, title: 'QO-C004: Shopping Cart' },
+  { path: '/qo-c-005', component: QoC005, title: 'QO-C005: Checkout' },
+  { path: '/qo-c-006', component: QoC006, title: 'QO-C006: Payment' },
+  { path: '/qo-c-007', component: QoC007, title: 'QO-C007: Order Status' },
+  { path: '/qo-c-008', component: QoC008, title: 'QO-C008: Order Confirmation' },
+];
 
-// A wrapper component to apply the tablet frame to pages
-const TabletFramedPage = ({ children }: { children: React.ReactNode }) => (
-  <TabletFrame>{children}</TabletFrame>
-);
+const staffJourney = [
+  { path: '/qo-s-001', component: QoS001, title: 'QO-S001: Staff Login' },
+  { path: '/qo-s-002', component: QoS002, title: 'QO-S002: Dashboard' },
+  { path: '/qo-s-003', component: QoS003, title: 'QO-S003: Order Management' },
+  { path: '/qo-s-004', component: QoS004, title: 'QO-S004: Kitchen Display' },
+  { path: '/qo-s-005', component: QoS005, title: 'QO-S005: Menu Management' },
+  { path: '/qo-s-006', component: QoS006, title: 'QO-S006: Table Management' },
+  { path: '/qo-s-007', component: QoS007, title: 'QO-S007: Customer Service' },
+  { path: '/qo-s-008', component: QoS008, title: 'QO-S008: Staff Analytics' },
+];
+
+const adminJourney = [
+  { path: '/qo-a-001', component: QoA001, title: 'QO-A001: Admin Dashboard' },
+  { path: '/qo-a-002', component: QoA002, title: 'QO-A002: Multi-Location Management' },
+  { path: '/qo-a-003', component: QoA003, title: 'QO-A003: Global Menu Management' },
+  { path: '/qo-a-004', component: QoA004, title: 'QO-A004: Staff Management' },
+  { path: '/qo-a-005', component: QoA005, title: 'QO-A005: Analytics & Reports' },
+  { path: '/qo-a-006', component: QoA006, title: 'QO-A006: System Settings' },
+];
+
+const placeholderDescription = "This is a placeholder description for the page. It will be replaced with more detailed information about the specific features and user interactions available on this screen.";
 
 function App() {
   return (
@@ -63,33 +85,62 @@ function App() {
           <Route path="/vt-l005" element={<VTL005 />} />
           <Route path="/vt-l017" element={<VTL017 />} />
 
-          {/* Customer Pages */}
-          <Route path="/qo-c-001" element={<FramedPage><QoC001 /></FramedPage>} />
-          <Route path="/qo-c-002" element={<FramedPage><QoC002 /></FramedPage>} />
-          <Route path="/qo-c-003" element={<FramedPage><QoC003 /></FramedPage>} />
-          <Route path="/qo-c-004" element={<FramedPage><QoC004 /></FramedPage>} />
-          <Route path="/qo-c-005" element={<FramedPage><QoC005 /></FramedPage>} />
-          <Route path="/qo-c-006" element={<FramedPage><QoC006 /></FramedPage>} />
-          <Route path="/qo-c-007" element={<FramedPage><QoC007 /></FramedPage>} />
-          <Route path="/qo-c-008" element={<FramedPage><QoC008 /></FramedPage>} />
+          {/* Customer Journey */}
+          {customerJourney.map((page, index) => (
+            <Route
+              key={page.path}
+              path={page.path}
+              element={
+                <ShowcasePageLayout
+                  title={page.title}
+                  description={placeholderDescription}
+                  previousLink={index > 0 ? customerJourney[index - 1].path : undefined}
+                  nextLink={index < customerJourney.length - 1 ? customerJourney[index + 1].path : undefined}
+                  journeyType="customer"
+                >
+                  <page.component />
+                </ShowcasePageLayout>
+              }
+            />
+          ))}
 
-          {/* Staff Pages */}
-          <Route path="/qo-s-001" element={<FramedPage><QoS001 /></FramedPage>} />
-          <Route path="/qo-s-002" element={<FramedPage><QoS002 /></FramedPage>} />
-          <Route path="/qo-s-003" element={<FramedPage><QoS003 /></FramedPage>} />
-          <Route path="/qo-s-004" element={<FramedPage><QoS004 /></FramedPage>} />
-          <Route path="/qo-s-005" element={<FramedPage><QoS005 /></FramedPage>} />
-          <Route path="/qo-s-006" element={<FramedPage><QoS006 /></FramedPage>} />
-          <Route path="/qo-s-007" element={<FramedPage><QoS007 /></FramedPage>} />
-          <Route path="/qo-s-008" element={<FramedPage><QoS008 /></FramedPage>} />
+          {/* Staff Journey */}
+          {staffJourney.map((page, index) => (
+            <Route
+              key={page.path}
+              path={page.path}
+              element={
+                <ShowcasePageLayout
+                  title={page.title}
+                  description={placeholderDescription}
+                  previousLink={index > 0 ? staffJourney[index - 1].path : undefined}
+                  nextLink={index < staffJourney.length - 1 ? staffJourney[index + 1].path : undefined}
+                  journeyType="staff"
+                >
+                  <page.component />
+                </ShowcasePageLayout>
+              }
+            />
+          ))}
 
-          {/* Admin Pages */}
-          <Route path="/qo-a-001" element={<TabletFramedPage><QoA001 /></TabletFramedPage>} />
-          <Route path="/qo-a-002" element={<TabletFramedPage><QoA002 /></TabletFramedPage>} />
-          <Route path="/qo-a-003" element={<TabletFramedPage><QoA003 /></TabletFramedPage>} />
-          <Route path="/qo-a-004" element={<TabletFramedPage><QoA004 /></TabletFramedPage>} />
-          <Route path="/qo-a-005" element={<TabletFramedPage><QoA005 /></TabletFramedPage>} />
-          <Route path="/qo-a-006" element={<TabletFramedPage><QoA006 /></TabletFramedPage>} />
+          {/* Admin Journey */}
+          {adminJourney.map((page, index) => (
+            <Route
+              key={page.path}
+              path={page.path}
+              element={
+                <ShowcasePageLayout
+                  title={page.title}
+                  description={placeholderDescription}
+                  previousLink={index > 0 ? adminJourney[index - 1].path : undefined}
+                  nextLink={index < adminJourney.length - 1 ? adminJourney[index + 1].path : undefined}
+                  journeyType="admin"
+                >
+                  <page.component />
+                </ShowcasePageLayout>
+              }
+            />
+          ))}
         </Routes>
       </BrowserRouter>
     </LanguageProvider>

--- a/src/components/ShowcasePageLayout.tsx
+++ b/src/components/ShowcasePageLayout.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { ArrowLeft, ArrowRight, X } from 'lucide-react';
+import IphoneFrame from './iPhoneFrame';
+import TabletFrame from './TabletFrame';
+
+interface ShowcasePageLayoutProps {
+  title: string;
+  description: string;
+  previousLink?: string;
+  nextLink?: string;
+  journeyType: 'customer' | 'staff' | 'admin';
+  children: React.ReactNode;
+}
+
+const ShowcasePageLayout: React.FC<ShowcasePageLayoutProps> = ({
+  title,
+  description,
+  previousLink,
+  nextLink,
+  journeyType,
+  children,
+}) => {
+  const DeviceFrame = journeyType === 'admin' ? TabletFrame : IphoneFrame;
+
+  return (
+    <div className="flex flex-col lg:flex-row h-screen bg-gray-800 text-white">
+      {/* Left Panel: Info and Navigation */}
+      <div className="w-full lg:w-80 xl:w-96 bg-gray-900 p-8 flex flex-col justify-between order-2 lg:order-1">
+        <div>
+          <h1 className="text-2xl font-bold text-purple-400 mb-2">{title}</h1>
+          <p className="text-gray-300 leading-relaxed">
+            {description}
+          </p>
+        </div>
+        <div className="mt-8">
+          <h3 className="text-lg font-semibold mb-4">Journey Navigation</h3>
+          <div className="flex space-x-4">
+            {previousLink ? (
+              <Link to={previousLink} className="flex-1 bg-gray-700 hover:bg-gray-600 text-white font-bold py-3 px-4 rounded-lg flex items-center justify-center transition-colors">
+                <ArrowLeft className="w-5 h-5 mr-2" />
+                Previous
+              </Link>
+            ) : (
+              <div className="flex-1 bg-gray-800 text-gray-500 font-bold py-3 px-4 rounded-lg flex items-center justify-center cursor-not-allowed">
+                <ArrowLeft className="w-5 h-5 mr-2" />
+                Previous
+              </div>
+            )}
+            {nextLink ? (
+              <Link to={nextLink} className="flex-1 bg-gray-700 hover:bg-gray-600 text-white font-bold py-3 px-4 rounded-lg flex items-center justify-center transition-colors">
+                Next
+                <ArrowRight className="w-5 h-5 ml-2" />
+              </Link>
+            ) : (
+              <div className="flex-1 bg-gray-800 text-gray-500 font-bold py-3 px-4 rounded-lg flex items-center justify-center cursor-not-allowed">
+                Next
+                <ArrowRight className="w-5 h-5 ml-2" />
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Right Panel: Device Frame */}
+      <div className="flex-1 flex items-center justify-center p-4 relative order-1 lg:order-2">
+        <Link
+          to="/samples"
+          className="absolute top-4 right-4 bg-gray-700 hover:bg-gray-600 text-white rounded-full p-3 z-20"
+          aria-label="Exit Showcase"
+        >
+          <X className="w-6 h-6" />
+        </Link>
+        <DeviceFrame>{children}</DeviceFrame>
+      </div>
+    </div>
+  );
+};
+
+export default ShowcasePageLayout;

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
-import { ExternalLink, Users, Shield, UserCheck } from 'lucide-react';
+import { ArrowRight, Users, Shield, UserCheck } from 'lucide-react';
 
 const adminPages = [
   { href: '/qo-a-001', title: 'QO-A001: Admin Dashboard' },
@@ -37,12 +37,10 @@ const PageLink: React.FC<{ href: string; title: string }> = ({ href, title }) =>
   <li className="mb-2">
     <Link
       to={href}
-      target="_blank"
-      rel="noopener noreferrer"
       className="flex items-center justify-between p-4 bg-gray-50 hover:bg-gray-100 rounded-lg transition-colors duration-200 group"
     >
       <span className="font-medium text-gray-700 group-hover:text-purple-600">{title}</span>
-      <ExternalLink className="w-5 h-5 text-gray-400 group-hover:text-purple-600 transition-colors" />
+      <ArrowRight className="w-5 h-5 text-gray-400 group-hover:text-purple-600 transition-colors" />
     </Link>
   </li>
 );


### PR DESCRIPTION
This commit completely refactors the sample page showcase to create a more immersive and guided user experience, based on user feedback.

- Created a new `ShowcasePageLayout.tsx` component that wraps each sample page. This layout includes a description panel, "Previous" and "Next" navigation buttons, and an "Exit" button.
- Refactored the routing in `App.tsx` to use the new layout for all customer, staff, and admin sample pages. The routes are now generated from journey-specific arrays, which simplifies the logic for sequential navigation.
- Removed the old `FramedPage` and `TabletFramedPage` wrappers, as their logic is now handled by `ShowcasePageLayout`.
- Updated `HomePage.tsx` to remove `target="_blank"` from links, ensuring the showcase experience happens in the same tab.
- Replaced the `ExternalLink` icon with `ArrowRight` on the showcase page to better represent in-app navigation.