### PR TITLE
feat: Enhance showcase with new pages and detailed descriptions

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,12 +5,14 @@ import ShowcasePageLayout from './components/ShowcasePageLayout';
 
 // Import all page components
 import HomePage from './pages/HomePage';
-import QoA001 from './pages/samples/admin/qo-a001-admin_dashboard';
-import QoA002 from './pages/samples/admin/qo-a002-multi_location_management';
-import QoA003 from './pages/samples/admin/qo-a003-global_menu_management';
-import QoA004 from './pages/samples/admin/qo-a004-staff_management';
-import QoA005 from './pages/samples/admin/qo-a005-analytics_reports';
-import QoA006 from './pages/samples/admin/qo-a006-system_settings_fixed';
+import VTL001 from './pages/vt-l001-viatable_landing_page';
+import VTL002 from './pages/vt-l002-viatable_signup_flow';
+import VTL003 from './pages/vt-l003-viatable_pricing_plans';
+import VTL004 from './pages/vt-l004-viatable_demo_trial';
+import VTL005 from './pages/vt-l005-viatable_features_new';
+import VTL017 from './pages/vt-l017-viatable_login_new';
+
+// Customer pages
 import QoC001 from './pages/qo_c001_landing';
 import QoC002 from './pages/qo_c002_menu';
 import QoC003 from './pages/qo_c003_item_details';
@@ -19,6 +21,8 @@ import QoC005 from './pages/qo_c005_checkout';
 import QoC006 from './pages/qo_c006_payment';
 import QoC007 from './pages/qo_c007_order_status';
 import QoC008 from './pages/qo_c008_confirmation';
+
+// Staff pages
 import QoS001 from './pages/qo_s001_staff_login';
 import QoS002 from './pages/qo_s002_dashboard';
 import QoS003 from './pages/qo_s003_order_management';
@@ -28,46 +32,58 @@ import QoS006 from './pages/qo_s006_table_management';
 import QoS007 from './pages/qo_s007_customer_service';
 import QoS008 from './pages/qo_s008_staff_analytics';
 
-// Viatable sample pages
-import VTL001 from './pages/vt-l001-viatable_landing_page';
-import VTL002 from './pages/vt-l002-viatable_signup_flow';
-import VTL003 from './pages/vt-l003-viatable_pricing_plans';
-import VTL004 from './pages/vt-l004-viatable_demo_trial';
-import VTL005 from './pages/vt-l005-viatable_features_new';
-import VTL017 from './pages/vt-l017-viatable_login_new';
+// Admin pages
+import QoA001 from './pages/samples/admin/qo-a001-admin_dashboard';
+import QoA002 from './pages/samples/admin/qo-a002-multi_location_management';
+import QoA003 from './pages/samples/admin/qo-a003-global_menu_management';
+import QoA004 from './pages/samples/admin/qo-a004-staff_management';
+import QoA005 from './pages/samples/admin/qo-a005-analytics_reports';
+import QoA006 from './pages/samples/admin/qo-a006-system_settings_fixed';
+import QoA007 from './pages/samples/admin/qo-a007-payment_management';
+import QoA008 from './pages/samples/admin/qo-a008-customer_management';
+import QoA009 from './pages/samples/admin/qo-a009-inventory_management';
+import QoA010 from './pages/samples/admin/qo-a010-promotion_management';
+import QoA011 from './pages/samples/admin/qo-a011-audit_logs';
+import QoA012 from './pages/samples/admin/qo-a012-qr_code_management';
+
 
 const customerJourney = [
-  { path: '/qo-c-001', component: QoC001, title: 'QO-C001: Landing Page' },
-  { path: '/qo-c-002', component: QoC002, title: 'QO-C002: Menu Catalog' },
-  { path: '/qo-c-003', component: QoC003, title: 'QO-C003: Item Details' },
-  { path: '/qo-c-004', component: QoC004, title: 'QO-C004: Shopping Cart' },
-  { path: '/qo-c-005', component: QoC005, title: 'QO-C005: Checkout' },
-  { path: '/qo-c-006', component: QoC006, title: 'QO-C006: Payment' },
-  { path: '/qo-c-007', component: QoC007, title: 'QO-C007: Order Status' },
-  { path: '/qo-c-008', component: QoC008, title: 'QO-C008: Order Confirmation' },
+  { path: '/qo-c-001', component: QoC001, title: 'QO-C001: Landing/Welcome Page', description: 'The first touchpoint after QR code scanning, featuring multilingual language selection (English/Korean), table information display, and restaurant branding. Includes real-time clock, core feature preview, and intuitive navigation to the menu catalog.' },
+  { path: '/qo-c-002', component: QoC002, title: 'QO-C002: Menu Catalog', description: 'Comprehensive digital menu showcasing categorized food and beverage items with advanced filtering, search functionality, and real-time pricing. Features coffee & brunch items with emoji icons, ratings, and dynamic currency conversion.' },
+  { path: '/qo-c-003', component: QoC003, title: 'QO-C003: Item Details', description: 'Detailed product page showcasing individual menu items with comprehensive customization options, ingredient information, nutritional data, and allergen warnings. Example implementation features Avocado Toast with bread type selection and egg style options.' },
+  { path: '/qo-c-004', component: QoC004, title: 'QO-C004: Shopping Cart', description: 'Smart shopping cart management system with item modification capabilities, promotional code application, and real-time total calculation including taxes and service charges. Features estimated preparation time and special request handling.' },
+  { path: '/qo-c-005', component: QoC005, title: 'QO-C005: Checkout', description: 'Streamlined checkout process with customer information collection, service type selection (dine-in/takeaway), and multiple payment method options. Includes guest/member login options and real-time form validation.' },
+  { path: '/qo-c-006', component: QoC006, title: 'QO-C006: Payment', description: 'Secure payment processing interface with multiple authentication methods including biometric verification. Features card information masking, real-time processing status, and comprehensive security measures.' },
+  { path: '/qo-c-007', component: QoC007, title: 'QO-C007: Order Status', description: 'Real-time order tracking system displaying current order progress through multiple stages (Confirmed → Preparing → Ready for Pickup). Includes live timer, customer service options, and interactive progress indicators.' },
+  { path: '/qo-c-008', component: QoC008, title: 'QO-C008: Order Confirmation', description: 'Order completion confirmation page with QR code generation for order tracking, loyalty point accumulation, and next-step guidance. Emphasizes achievement and provides seamless reordering options.' },
 ];
 
 const staffJourney = [
-  { path: '/qo-s-001', component: QoS001, title: 'QO-S001: Staff Login' },
-  { path: '/qo-s-002', component: QoS002, title: 'QO-S002: Dashboard' },
-  { path: '/qo-s-003', component: QoS003, title: 'QO-S003: Order Management' },
-  { path: '/qo-s-004', component: QoS004, title: 'QO-S004: Kitchen Display' },
-  { path: '/qo-s-005', component: QoS005, title: 'QO-S005: Menu Management' },
-  { path: '/qo-s-006', component: QoS006, title: 'QO-S006: Table Management' },
-  { path: '/qo-s-007', component: QoS007, title: 'QO-S007: Customer Service' },
-  { path: '/qo-s-008', component: QoS008, title: 'QO-S008: Staff Analytics' },
+  { path: '/qo-s-001', component: QoS001, title: 'QO-S001: Staff Login', description: 'Multi-authentication login system supporting password, PIN, and QR code access methods. Features security monitoring, login attempt tracking, and real-time system status display with current online staff visibility.' },
+  { path: '/qo-s-002', component: QoS002, title: 'QO-S002: Staff Dashboard', description: 'Personalized staff dashboard with individual performance metrics, real-time work hour tracking, and key performance indicators. Features clock-in/out functionality and live activity feed with today\'s statistics.' },
+  { path: '/qo-s-003', component: QoS003, title: 'QO-S003: Order Management', description: 'Comprehensive order management system with status-based filtering, bulk processing capabilities, and priority ordering. Features real-time search, one-click status updates, and automated workflow management.' },
+  { path: '/qo-s-004', component: QoS004, title: 'QO-S004: Kitchen Display', description: 'Kitchen-optimized display system with 3-stage kanban board layout, dark theme for reduced eye strain, and real-time preparation timers. Features automatic delay detection and allergen warning highlights.' },
+  { path: '/qo-s-005', component: QoS005, title: 'QO-S005: Menu Management', description: 'Real-time menu management interface for price adjustments, inventory control, and item availability management. Features popular item analytics, sales trend tracking, and one-touch item enable/disable functionality.' },
+  { path: '/qo-s-006', component: QoS006, title: 'QO-S006: Table Management', description: 'Comprehensive table status management system with QR code generation, zone-based organization, and real-time occupancy tracking. Features customer contact integration and status-based color coding.' },
+  { path: '/qo-s-007', component: QoS007, title: 'QO-S007: Customer Service', description: 'Advanced customer service management system with real-time chat functionality, priority-based request handling, and comprehensive response time tracking. Features categorized request types and satisfaction measurement.' },
+  { path: '/qo-s-008', component: QoS008, title: 'QO-S008: Staff Analytics', description: 'Individual and team performance analytics dashboard with goal management, achievement tracking, and competitive rankings. Features real-time performance monitoring, badge systems, and trend analysis.' },
 ];
 
 const adminJourney = [
-  { path: '/qo-a-001', component: QoA001, title: 'QO-A001: Admin Dashboard' },
-  { path: '/qo-a-002', component: QoA002, title: 'QO-A002: Multi-Location Management' },
-  { path: '/qo-a-003', component: QoA003, title: 'QO-A003: Global Menu Management' },
-  { path: '/qo-a-004', component: QoA004, title: 'QO-A004: Staff Management' },
-  { path: '/qo-a-005', component: QoA005, title: 'QO-A005: Analytics & Reports' },
-  { path: '/qo-a-006', component: QoA006, title: 'QO-A006: System Settings' },
+  { path: '/qo-a-001', component: QoA001, title: 'QO-A001: Admin Dashboard', description: 'Executive-level dashboard providing comprehensive business overview with multi-location performance metrics, revenue analytics, and system-wide KPIs. Features real-time monitoring of all business operations across multiple venues.' },
+  { path: '/qo-a-002', component: QoA002, title: 'QO-A002: Multi-Location Management', description: 'Centralized management interface for multiple restaurant locations with individual performance tracking, standardized menu distribution, and location-specific customization capabilities.' },
+  { path: '/qo-a-003', component: QoA003, title: 'QO-A003: Global Menu Management', description: 'Enterprise-level menu management system for standardizing offerings across multiple locations while allowing location-specific modifications. Features bulk pricing updates and global inventory coordination.' },
+  { path: '/qo-a-004', component: QoA004, title: 'QO-A004: Staff Management', description: 'Comprehensive human resource management system for employee accounts, role assignments, permission management, and performance tracking across all locations with scheduling integration.' },
+  { path: '/qo-a-005', component: QoA005, title: 'QO-A005: Analytics & Reports', description: 'Advanced business intelligence platform providing detailed analytics, custom report generation, and predictive insights for strategic decision-making with exportable data formats.' },
+  { path: '/qo-a-006', component: QoA006, title: 'QO-A006: System Settings', description: 'System-wide configuration management interface for global settings, integration management, security protocols, and platform customization with backup and restore capabilities.' },
+  { path: '/qo-a-007', component: QoA007, title: 'QO-A007: Payment Management', description: 'Financial operations management system handling payment processing, settlement tracking, fee management, and financial reporting with integration to accounting systems.' },
+  { path: '/qo-a-008', component: QoA008, title: 'QO-A008: Customer Management', description: 'Customer relationship management system providing customer data analytics, feedback management, loyalty program administration, and personalized marketing campaign tools.' },
+  { path: '/qo-a-009', component: QoA009, title: 'QO-A009: Inventory Management', description: 'Enterprise inventory management system with automated reordering, supplier integration, waste tracking, and cost optimization across all locations with predictive analytics.' },
+  { path: '/qo-a-010', component: QoA010, title: 'QO-A010: Promotion Management', description: 'Marketing campaign management system for creating, managing, and tracking promotional campaigns, discount codes, and loyalty programs with performance analytics and ROI measurement.' },
+  { path: '/qo-a-011', component: QoA011, title: 'QO-A011: Audit Logs', description: 'Comprehensive system audit and compliance tracking interface providing detailed logs of all system activities, security events, and compliance monitoring with forensic analysis capabilities.' },
+  { path: '/qo-a-012', component: QoA012, title: 'QO-A012: QR Code Management', description: 'QR code generation and management system for creating, tracking, and updating QR codes across all locations with analytics on scan rates, performance metrics, and security management.' },
 ];
 
-const placeholderDescription = "This is a placeholder description for the page. It will be replaced with more detailed information about the specific features and user interactions available on this screen.";
 
 function App() {
   return (
@@ -93,7 +109,7 @@ function App() {
               element={
                 <ShowcasePageLayout
                   title={page.title}
-                  description={placeholderDescription}
+                  description={page.description}
                   previousLink={index > 0 ? customerJourney[index - 1].path : undefined}
                   nextLink={index < customerJourney.length - 1 ? customerJourney[index + 1].path : undefined}
                   journeyType="customer"
@@ -112,7 +128,7 @@ function App() {
               element={
                 <ShowcasePageLayout
                   title={page.title}
-                  description={placeholderDescription}
+                  description={page.description}
                   previousLink={index > 0 ? staffJourney[index - 1].path : undefined}
                   nextLink={index < staffJourney.length - 1 ? staffJourney[index + 1].path : undefined}
                   journeyType="staff"
@@ -131,7 +147,7 @@ function App() {
               element={
                 <ShowcasePageLayout
                   title={page.title}
-                  description={placeholderDescription}
+                  description={page.description}
                   previousLink={index > 0 ? adminJourney[index - 1].path : undefined}
                   nextLink={index < adminJourney.length - 1 ? adminJourney[index + 1].path : undefined}
                   journeyType="admin"

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -9,6 +9,12 @@ const adminPages = [
   { href: '/qo-a-004', title: 'QO-A004: Staff Management' },
   { href: '/qo-a-005', title: 'QO-A005: Analytics & Reports' },
   { href: '/qo-a-006', title: 'QO-A006: System Settings' },
+  { href: '/qo-a-007', title: 'QO-A007: Payment Management' },
+  { href: '/qo-a-008', title: 'QO-A008: Customer Management' },
+  { href: '/qo-a-009', title: 'QO-A009: Inventory Management' },
+  { href: '/qo-a-010', title: 'QO-A010: Promotion Management' },
+  { href: '/qo-a-011', title: 'QO-A011: Audit Logs' },
+  { href: '/qo-a-012', title: 'QO-A012: QR Code Management' },
 ];
 
 const customerPages = [
@@ -46,9 +52,27 @@ const PageLink: React.FC<{ href: string; title: string }> = ({ href, title }) =>
 );
 
 const TABS = [
-  { id: 'admin', name: 'Administrator', icon: Shield, pages: adminPages },
-  { id: 'customer', name: 'Customer Journey', icon: Users, pages: customerPages },
-  { id: 'staff', name: 'Staff Interface', icon: UserCheck, pages: staffPages },
+  {
+    id: 'admin',
+    name: 'Administrator',
+    icon: Shield,
+    pages: adminPages,
+    description: 'Explore the powerful, centralized dashboard for multi-location management, global menu configuration, and system-wide analytics. This journey is designed for business owners and administrators to monitor and control the entire operation.'
+  },
+  {
+    id: 'customer',
+    name: 'Customer Journey',
+    icon: Users,
+    pages: customerPages,
+    description: 'Experience the seamless customer flow from scanning a QR code to placing an order and making a payment. This journey showcases the intuitive, user-friendly interface that your customers will love.'
+  },
+  {
+    id: 'staff',
+    name: 'Staff Interface',
+    icon: UserCheck,
+    pages: staffPages,
+    description: 'See how your staff will manage orders, update table statuses, and interact with the kitchen display. This journey is optimized for efficiency and clear communication in a fast-paced restaurant environment.'
+  },
 ];
 
 const HomePage: React.FC = () => {
@@ -57,14 +81,14 @@ const HomePage: React.FC = () => {
   const activeTabData = TABS.find(tab => tab.id === activeTab);
 
   return (
-    <div className="bg-white min-h-screen">
+    <div className="bg-gray-50 min-h-screen">
       <div className="bg-gray-900 text-white">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16 text-center">
           <h1 className="text-4xl font-extrabold sm:text-5xl md:text-6xl bg-gradient-to-r from-purple-400 to-pink-500 bg-clip-text text-transparent">
             Interactive Product Showcase
           </h1>
           <p className="mt-4 max-w-2xl mx-auto text-xl text-gray-300">
-            Explore the core user journeys of the VIATABLE platform. Click on any page to open a live, interactive demo in a new tab.
+            Explore the core user journeys of the VIATABLE platform. Click on any page to start an interactive, guided tour of our key features.
           </p>
         </div>
       </div>
@@ -91,11 +115,14 @@ const HomePage: React.FC = () => {
 
         <div>
           {activeTabData && (
-            <div className="bg-white p-6 rounded-xl shadow-lg border border-gray-100">
-              <h2 className="text-2xl font-bold text-gray-800 mb-4 flex items-center">
-                <activeTabData.icon className="w-7 h-7 mr-3 text-purple-500" />
-                {activeTabData.name}
-              </h2>
+            <div className="bg-white p-8 rounded-xl shadow-lg border border-gray-100">
+              <div className="mb-6">
+                <h2 className="text-3xl font-bold text-gray-800 mb-2 flex items-center">
+                  <activeTabData.icon className="w-8 h-8 mr-3 text-purple-500" />
+                  {activeTabData.name}
+                </h2>
+                <p className="text-gray-600">{activeTabData.description}</p>
+              </div>
               <ul className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
                 {activeTabData.pages.map((page) => (
                   <PageLink key={page.href} {...page} />

--- a/src/pages/samples/admin/qo-a001-admin_dashboard.tsx
+++ b/src/pages/samples/admin/qo-a001-admin_dashboard.tsx
@@ -120,7 +120,7 @@ const AdminDashboard = () => {
 
       <div className="p-6">
         {/* Key Metrics */}
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
+        <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-6 mb-8">
           <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
             <div className="flex items-center justify-between mb-4">
               <div className="flex items-center space-x-3">

--- a/src/pages/samples/admin/qo-a002-multi_location_management.tsx
+++ b/src/pages/samples/admin/qo-a002-multi_location_management.tsx
@@ -344,7 +344,7 @@ const MultiLocationManagement = () => {
         </div>
 
         {/* Summary Stats */}
-        <div className="grid grid-cols-1 md:grid-cols-4 gap-4 mb-6">
+        <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-4 mb-6">
           <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-4">
             <div className="flex items-center space-x-3">
               <div className="p-2 bg-green-100 rounded-lg">

--- a/src/pages/samples/admin/qo-a003-global_menu_management.tsx
+++ b/src/pages/samples/admin/qo-a003-global_menu_management.tsx
@@ -342,8 +342,8 @@ const GlobalMenuManagement = () => {
 
       <div className="p-6">
         {/* Filters and Search */}
-        <div className="grid grid-cols-1 md:grid-cols-6 gap-4 mb-6">
-          <div className="md:col-span-2 relative">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 xl:grid-cols-6 gap-4 mb-6">
+          <div className="lg:col-span-2 relative">
             <Search className="w-4 h-4 absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400" />
             <input
               type="text"
@@ -409,7 +409,7 @@ const GlobalMenuManagement = () => {
         </div>
 
         {/* Summary Stats */}
-        <div className="grid grid-cols-1 md:grid-cols-4 gap-4 mb-6">
+        <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-4 mb-6">
           <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-4">
             <div className="flex items-center space-x-3">
               <div className="p-2 bg-blue-100 rounded-lg">

--- a/src/pages/samples/admin/qo-a004-staff_management.tsx
+++ b/src/pages/samples/admin/qo-a004-staff_management.tsx
@@ -338,8 +338,8 @@ const StaffManagement = () => {
 
       <div className="p-6">
         {/* Filters and Search */}
-        <div className="grid grid-cols-1 md:grid-cols-6 gap-4 mb-6">
-          <div className="md:col-span-2 relative">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 xl:grid-cols-6 gap-4 mb-6">
+          <div className="lg:col-span-2 relative">
             <Search className="w-4 h-4 absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400" />
             <input
               type="text"
@@ -405,7 +405,7 @@ const StaffManagement = () => {
         </div>
 
         {/* Summary Stats */}
-        <div className="grid grid-cols-1 md:grid-cols-5 gap-4 mb-6">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5 gap-4 mb-6">
           <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-4">
             <div className="flex items-center space-x-3">
               <div className="p-2 bg-blue-100 rounded-lg">

--- a/src/pages/samples/admin/qo-a005-analytics_reports.tsx
+++ b/src/pages/samples/admin/qo-a005-analytics_reports.tsx
@@ -380,7 +380,7 @@ const AnalyticsReports = () => {
         </div>
 
         {/* Key Metrics */}
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
+        <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-6 mb-8">
           <MetricCard
             title="Total Revenue"
             value={analyticsData.overview.totalRevenue.value}
@@ -429,7 +429,7 @@ const AnalyticsReports = () => {
         </div>
 
         {/* Additional Insights */}
-        <div className="mt-8 grid grid-cols-1 md:grid-cols-3 gap-6">
+        <div className="mt-8 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
           <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
             <div className="flex items-center space-x-3 mb-4">
               <div className="p-2 bg-green-100 rounded-lg">

--- a/src/pages/samples/admin/qo-a007-payment_management.tsx
+++ b/src/pages/samples/admin/qo-a007-payment_management.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const PaymentManagement = () => {
+  return (
+    <div className="p-6 text-center text-gray-500">
+      <h1 className="text-2xl font-bold mb-4">QO-A007: Payment Management</h1>
+      <p>This page is under construction.</p>
+    </div>
+  );
+};
+
+export default PaymentManagement;

--- a/src/pages/samples/admin/qo-a008-customer_management.tsx
+++ b/src/pages/samples/admin/qo-a008-customer_management.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const CustomerManagement = () => {
+  return (
+    <div className="p-6 text-center text-gray-500">
+      <h1 className="text-2xl font-bold mb-4">QO-A008: Customer Management</h1>
+      <p>This page is under construction.</p>
+    </div>
+  );
+};
+
+export default CustomerManagement;

--- a/src/pages/samples/admin/qo-a009-inventory_management.tsx
+++ b/src/pages/samples/admin/qo-a009-inventory_management.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const InventoryManagement = () => {
+  return (
+    <div className="p-6 text-center text-gray-500">
+      <h1 className="text-2xl font-bold mb-4">QO-A009: Inventory Management</h1>
+      <p>This page is under construction.</p>
+    </div>
+  );
+};
+
+export default InventoryManagement;

--- a/src/pages/samples/admin/qo-a010-promotion_management.tsx
+++ b/src/pages/samples/admin/qo-a010-promotion_management.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const PromotionManagement = () => {
+  return (
+    <div className="p-6 text-center text-gray-500">
+      <h1 className="text-2xl font-bold mb-4">QO-A010: Promotion Management</h1>
+      <p>This page is under construction.</p>
+    </div>
+  );
+};
+
+export default PromotionManagement;

--- a/src/pages/samples/admin/qo-a011-audit_logs.tsx
+++ b/src/pages/samples/admin/qo-a011-audit_logs.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const AuditLogs = () => {
+  return (
+    <div className="p-6 text-center text-gray-500">
+      <h1 className="text-2xl font-bold mb-4">QO-A011: Audit Logs</h1>
+      <p>This page is under construction.</p>
+    </div>
+  );
+};
+
+export default AuditLogs;

--- a/src/pages/samples/admin/qo-a012-qr_code_management.tsx
+++ b/src/pages/samples/admin/qo-a012-qr_code_management.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const QrCodeManagement = () => {
+  return (
+    <div className="p-6 text-center text-gray-500">
+      <h1 className="text-2xl font-bold mb-4">QO-A012: QR Code Management</h1>
+      <p>This page is under construction.</p>
+    </div>
+  );
+};
+
+export default QrCodeManagement;


### PR DESCRIPTION
This commit implements a major content and layout update to the entire product showcase, based on detailed user-provided descriptions.

- **Adjusted Admin Layouts:** Refactored the CSS grids on existing admin pages (qo-a001 to qo-a006) to better fit the landscape tablet view.
- **Added New Admin Pages:** Created placeholder components for new admin pages (qo-a007 to qo-a012) and integrated them into the admin journey.
- **Updated Showcase Descriptions:**
  - Replaced all placeholder descriptions in `App.tsx` with the detailed, user-provided content for every page in the customer, staff, and admin journeys.
  - Updated the main showcase page (`HomePage.tsx`) with more engaging descriptions for each of the three journey tabs.
- **Expanded Admin Journey:** The `adminJourney` array in `App.tsx` now includes all 12 admin pages, providing a complete, navigable tour of the admin interface.