### PR TITLE
fix: Revert tablet frame size and restore showcase functionality

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,18 @@
 import React from 'react';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { LanguageProvider } from './contexts/LanguageContext';
-import IphoneFrame from './components/iPhoneFrame';
+import ShowcasePageLayout from './components/ShowcasePageLayout';
 
 // Import all page components
 import HomePage from './pages/HomePage';
+import VTL001 from './pages/vt-l001-viatable_landing_page';
+import VTL002 from './pages/vt-l002-viatable_signup_flow';
+import VTL003 from './pages/vt-l003-viatable_pricing_plans';
+import VTL004 from './pages/vt-l004-viatable_demo_trial';
+import VTL005 from './pages/vt-l005-viatable_features_new';
+import VTL017 from './pages/vt-l017-viatable_login_new';
+
+// Customer pages
 import QoC001 from './pages/qo_c001_landing';
 import QoC002 from './pages/qo_c002_menu';
 import QoC003 from './pages/qo_c003_item_details';
@@ -13,6 +21,8 @@ import QoC005 from './pages/qo_c005_checkout';
 import QoC006 from './pages/qo_c006_payment';
 import QoC007 from './pages/qo_c007_order_status';
 import QoC008 from './pages/qo_c008_confirmation';
+
+// Staff pages
 import QoS001 from './pages/qo_s001_staff_login';
 import QoS002 from './pages/qo_s002_dashboard';
 import QoS003 from './pages/qo_s003_order_management';
@@ -22,18 +32,58 @@ import QoS006 from './pages/qo_s006_table_management';
 import QoS007 from './pages/qo_s007_customer_service';
 import QoS008 from './pages/qo_s008_staff_analytics';
 
-// Viatable sample pages
-import VTL001 from './pages/vt-l001-viatable_landing_page';
-import VTL002 from './pages/vt-l002-viatable_signup_flow';
-import VTL003 from './pages/vt-l003-viatable_pricing_plans';
-import VTL004 from './pages/vt-l004-viatable_demo_trial';
-import VTL005 from './pages/vt-l005-viatable_features_new';
-import VTL017 from './pages/vt-l017-viatable_login_new';
+// Admin pages
+import QoA001 from './pages/samples/admin/qo-a001-admin_dashboard';
+import QoA002 from './pages/samples/admin/qo-a002-multi_location_management';
+import QoA003 from './pages/samples/admin/qo-a003-global_menu_management';
+import QoA004 from './pages/samples/admin/qo-a004-staff_management';
+import QoA005 from './pages/samples/admin/qo-a005-analytics_reports';
+import QoA006 from './pages/samples/admin/qo-a006-system_settings_fixed';
+import QoA007 from './pages/samples/admin/qo-a007-payment_management';
+import QoA008 from './pages/samples/admin/qo-a008-customer_management';
+import QoA009 from './pages/samples/admin/qo-a009-inventory_management';
+import QoA010 from './pages/samples/admin/qo-a010-promotion_management';
+import QoA011 from './pages/samples/admin/qo-a011-audit_logs';
+import QoA012 from './pages/samples/admin/qo-a012-qr_code_management';
 
-// A wrapper component to apply the iPhone frame to pages
-const FramedPage = ({ children }: { children: React.ReactNode }) => (
-  <IphoneFrame>{children}</IphoneFrame>
-);
+
+const customerJourney = [
+  { path: '/qo-c-001', component: QoC001, title: 'QO-C001: Landing/Welcome Page', description: 'The first touchpoint after QR code scanning, featuring multilingual language selection (English/Korean), table information display, and restaurant branding. Includes real-time clock, core feature preview, and intuitive navigation to the menu catalog.' },
+  { path: '/qo-c-002', component: QoC002, title: 'QO-C002: Menu Catalog', description: 'Comprehensive digital menu showcasing categorized food and beverage items with advanced filtering, search functionality, and real-time pricing. Features coffee & brunch items with emoji icons, ratings, and dynamic currency conversion.' },
+  { path: '/qo-c-003', component: QoC003, title: 'QO-C003: Item Details', description: 'Detailed product page showcasing individual menu items with comprehensive customization options, ingredient information, nutritional data, and allergen warnings. Example implementation features Avocado Toast with bread type selection and egg style options.' },
+  { path: '/qo-c-004', component: QoC004, title: 'QO-C004: Shopping Cart', description: 'Smart shopping cart management system with item modification capabilities, promotional code application, and real-time total calculation including taxes and service charges. Features estimated preparation time and special request handling.' },
+  { path: '/qo-c-005', component: QoC005, title: 'QO-C005: Checkout', description: 'Streamlined checkout process with customer information collection, service type selection (dine-in/takeaway), and multiple payment method options. Includes guest/member login options and real-time form validation.' },
+  { path: '/qo-c-006', component: QoC006, title: 'QO-C006: Payment', description: 'Secure payment processing interface with multiple authentication methods including biometric verification. Features card information masking, real-time processing status, and comprehensive security measures.' },
+  { path: '/qo-c-007', component: QoC007, title: 'QO-C007: Order Status', description: 'Real-time order tracking system displaying current order progress through multiple stages (Confirmed → Preparing → Ready for Pickup). Includes live timer, customer service options, and interactive progress indicators.' },
+  { path: '/qo-c-008', component: QoC008, title: 'QO-C008: Order Confirmation', description: 'Order completion confirmation page with QR code generation for order tracking, loyalty point accumulation, and next-step guidance. Emphasizes achievement and provides seamless reordering options.' },
+];
+
+const staffJourney = [
+  { path: '/qo-s-001', component: QoS001, title: 'QO-S001: Staff Login', description: 'Multi-authentication login system supporting password, PIN, and QR code access methods. Features security monitoring, login attempt tracking, and real-time system status display with current online staff visibility.' },
+  { path: '/qo-s-002', component: QoS002, title: 'QO-S002: Staff Dashboard', description: 'Personalized staff dashboard with individual performance metrics, real-time work hour tracking, and key performance indicators. Features clock-in/out functionality and live activity feed with today\'s statistics.' },
+  { path: '/qo-s-003', component: QoS003, title: 'QO-S003: Order Management', description: 'Comprehensive order management system with status-based filtering, bulk processing capabilities, and priority ordering. Features real-time search, one-click status updates, and automated workflow management.' },
+  { path: '/qo-s-004', component: QoS004, title: 'QO-S004: Kitchen Display', description: 'Kitchen-optimized display system with 3-stage kanban board layout, dark theme for reduced eye strain, and real-time preparation timers. Features automatic delay detection and allergen warning highlights.' },
+  { path: '/qo-s-005', component: QoS005, title: 'QO-S005: Menu Management', description: 'Real-time menu management interface for price adjustments, inventory control, and item availability management. Features popular item analytics, sales trend tracking, and one-touch item enable/disable functionality.' },
+  { path: '/qo-s-006', component: QoS006, title: 'QO-S006: Table Management', description: 'Comprehensive table status management system with QR code generation, zone-based organization, and real-time occupancy tracking. Features customer contact integration and status-based color coding.' },
+  { path: '/qo-s-007', component: QoS007, title: 'QO-S007: Customer Service', description: 'Advanced customer service management system with real-time chat functionality, priority-based request handling, and comprehensive response time tracking. Features categorized request types and satisfaction measurement.' },
+  { path: '/qo-s-008', component: QoS008, title: 'QO-S008: Staff Analytics', description: 'Individual and team performance analytics dashboard with goal management, achievement tracking, and competitive rankings. Features real-time performance monitoring, badge systems, and trend analysis.' },
+];
+
+const adminJourney = [
+  { path: '/qo-a-001', component: QoA001, title: 'QO-A001: Admin Dashboard', description: 'Executive-level dashboard providing comprehensive business overview with multi-location performance metrics, revenue analytics, and system-wide KPIs. Features real-time monitoring of all business operations across multiple venues.' },
+  { path: '/qo-a-002', component: QoA002, title: 'QO-A002: Multi-Location Management', description: 'Centralized management interface for multiple restaurant locations with individual performance tracking, standardized menu distribution, and location-specific customization capabilities.' },
+  { path: '/qo-a-003', component: QoA003, title: 'QO-A003: Global Menu Management', description: 'Enterprise-level menu management system for standardizing offerings across multiple locations while allowing location-specific modifications. Features bulk pricing updates and global inventory coordination.' },
+  { path: '/qo-a-004', component: QoA004, title: 'QO-A004: Staff Management', description: 'Comprehensive human resource management system for employee accounts, role assignments, permission management, and performance tracking across all locations with scheduling integration.' },
+  { path: '/qo-a-005', component: QoA005, title: 'QO-A005: Analytics & Reports', description: 'Advanced business intelligence platform providing detailed analytics, custom report generation, and predictive insights for strategic decision-making with exportable data formats.' },
+  { path: '/qo-a-006', component: QoA006, title: 'QO-A006: System Settings', description: 'System-wide configuration management interface for global settings, integration management, security protocols, and platform customization with backup and restore capabilities.' },
+  { path: '/qo-a-007', component: QoA007, title: 'QO-A007: Payment Management', description: 'Financial operations management system handling payment processing, settlement tracking, fee management, and financial reporting with integration to accounting systems.' },
+  { path: '/qo-a-008', component: QoA008, title: 'QO-A008: Customer Management', description: 'Customer relationship management system providing customer data analytics, feedback management, loyalty program administration, and personalized marketing campaign tools.' },
+  { path: '/qo-a-009', component: QoA009, title: 'QO-A009: Inventory Management', description: 'Enterprise inventory management system with automated reordering, supplier integration, waste tracking, and cost optimization across all locations with predictive analytics.' },
+  { path: '/qo-a-010', component: QoA010, title: 'QO-A010: Promotion Management', description: 'Marketing campaign management system for creating, managing, and tracking promotional campaigns, discount codes, and loyalty programs with performance analytics and ROI measurement.' },
+  { path: '/qo-a-011', component: QoA011, title: 'QO-A011: Audit Logs', description: 'Comprehensive system audit and compliance tracking interface providing detailed logs of all system activities, security events, and compliance monitoring with forensic analysis capabilities.' },
+  { path: '/qo-a-012', component: QoA012, title: 'QO-A012: QR Code Management', description: 'QR code generation and management system for creating, tracking, and updating QR codes across all locations with analytics on scan rates, performance metrics, and security management.' },
+];
+
 
 function App() {
   return (
@@ -51,25 +101,62 @@ function App() {
           <Route path="/vt-l005" element={<VTL005 />} />
           <Route path="/vt-l017" element={<VTL017 />} />
 
-          {/* Customer Pages */}
-          <Route path="/qo-c-001" element={<FramedPage><QoC001 /></FramedPage>} />
-          <Route path="/qo-c-002" element={<FramedPage><QoC002 /></FramedPage>} />
-          <Route path="/qo-c-003" element={<FramedPage><QoC003 /></FramedPage>} />
-          <Route path="/qo-c-004" element={<FramedPage><QoC004 /></FramedPage>} />
-          <Route path="/qo-c-005" element={<FramedPage><QoC005 /></FramedPage>} />
-          <Route path="/qo-c-006" element={<FramedPage><QoC006 /></FramedPage>} />
-          <Route path="/qo-c-007" element={<FramedPage><QoC007 /></FramedPage>} />
-          <Route path="/qo-c-008" element={<FramedPage><QoC008 /></FramedPage>} />
+          {/* Customer Journey */}
+          {customerJourney.map((page, index) => (
+            <Route
+              key={page.path}
+              path={page.path}
+              element={
+                <ShowcasePageLayout
+                  title={page.title}
+                  description={page.description}
+                  previousLink={index > 0 ? customerJourney[index - 1].path : undefined}
+                  nextLink={index < customerJourney.length - 1 ? customerJourney[index + 1].path : undefined}
+                  journeyType="customer"
+                >
+                  <page.component />
+                </ShowcasePageLayout>
+              }
+            />
+          ))}
 
-          {/* Staff Pages */}
-          <Route path="/qo-s-001" element={<FramedPage><QoS001 /></FramedPage>} />
-          <Route path="/qo-s-002" element={<FramedPage><QoS002 /></FramedPage>} />
-          <Route path="/qo-s-003" element={<FramedPage><QoS003 /></FramedPage>} />
-          <Route path="/qo-s-004" element={<FramedPage><QoS004 /></FramedPage>} />
-          <Route path="/qo-s-005" element={<FramedPage><QoS005 /></FramedPage>} />
-          <Route path="/qo-s-006" element={<FramedPage><QoS006 /></FramedPage>} />
-          <Route path="/qo-s-007" element={<FramedPage><QoS007 /></FramedPage>} />
-          <Route path="/qo-s-008" element={<FramedPage><QoS008 /></FramedPage>} />
+          {/* Staff Journey */}
+          {staffJourney.map((page, index) => (
+            <Route
+              key={page.path}
+              path={page.path}
+              element={
+                <ShowcasePageLayout
+                  title={page.title}
+                  description={page.description}
+                  previousLink={index > 0 ? staffJourney[index - 1].path : undefined}
+                  nextLink={index < staffJourney.length - 1 ? staffJourney[index + 1].path : undefined}
+                  journeyType="staff"
+                >
+                  <page.component />
+                </ShowcasePageLayout>
+              }
+            />
+          ))}
+
+          {/* Admin Journey */}
+          {adminJourney.map((page, index) => (
+            <Route
+              key={page.path}
+              path={page.path}
+              element={
+                <ShowcasePageLayout
+                  title={page.title}
+                  description={page.description}
+                  previousLink={index > 0 ? adminJourney[index - 1].path : undefined}
+                  nextLink={index < adminJourney.length - 1 ? adminJourney[index + 1].path : undefined}
+                  journeyType="admin"
+                >
+                  <page.component />
+                </ShowcasePageLayout>
+              }
+            />
+          ))}
         </Routes>
       </BrowserRouter>
     </LanguageProvider>

--- a/src/components/ShowcasePageLayout.tsx
+++ b/src/components/ShowcasePageLayout.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { ArrowLeft, ArrowRight, X } from 'lucide-react';
+import IphoneFrame from './iPhoneFrame';
+import TabletFrame from './TabletFrame';
+
+interface ShowcasePageLayoutProps {
+  title: string;
+  description: string;
+  previousLink?: string;
+  nextLink?: string;
+  journeyType: 'customer' | 'staff' | 'admin';
+  children: React.ReactNode;
+}
+
+const ShowcasePageLayout: React.FC<ShowcasePageLayoutProps> = ({
+  title,
+  description,
+  previousLink,
+  nextLink,
+  journeyType,
+  children,
+}) => {
+  const DeviceFrame = journeyType === 'admin' ? TabletFrame : IphoneFrame;
+
+  return (
+    <div className="flex flex-col lg:flex-row h-screen bg-gray-800 text-white">
+      {/* Left Panel: Info and Navigation */}
+      <div className="w-full lg:w-80 xl:w-96 bg-gray-900 p-8 flex flex-col justify-between order-2 lg:order-1">
+        <div>
+          <h1 className="text-2xl font-bold text-purple-400 mb-2">{title}</h1>
+          <p className="text-gray-300 leading-relaxed">
+            {description}
+          </p>
+        </div>
+        <div className="mt-8">
+          <h3 className="text-lg font-semibold mb-4">Journey Navigation</h3>
+          <div className="flex space-x-4">
+            {previousLink ? (
+              <Link to={previousLink} className="flex-1 bg-gray-700 hover:bg-gray-600 text-white font-bold py-3 px-4 rounded-lg flex items-center justify-center transition-colors">
+                <ArrowLeft className="w-5 h-5 mr-2" />
+                Previous
+              </Link>
+            ) : (
+              <div className="flex-1 bg-gray-800 text-gray-500 font-bold py-3 px-4 rounded-lg flex items-center justify-center cursor-not-allowed">
+                <ArrowLeft className="w-5 h-5 mr-2" />
+                Previous
+              </div>
+            )}
+            {nextLink ? (
+              <Link to={nextLink} className="flex-1 bg-gray-700 hover:bg-gray-600 text-white font-bold py-3 px-4 rounded-lg flex items-center justify-center transition-colors">
+                Next
+                <ArrowRight className="w-5 h-5 ml-2" />
+              </Link>
+            ) : (
+              <div className="flex-1 bg-gray-800 text-gray-500 font-bold py-3 px-4 rounded-lg flex items-center justify-center cursor-not-allowed">
+                Next
+                <ArrowRight className="w-5 h-5 ml-2" />
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Right Panel: Device Frame */}
+      <div className="flex-1 flex items-center justify-center p-4 relative order-1 lg:order-2">
+        <Link
+          to="/samples"
+          className="absolute top-4 right-4 bg-gray-700 hover:bg-gray-600 text-white rounded-full p-3 z-20"
+          aria-label="Exit Showcase"
+        >
+          <X className="w-6 h-6" />
+        </Link>
+        <DeviceFrame>{children}</DeviceFrame>
+      </div>
+    </div>
+  );
+};
+
+export default ShowcasePageLayout;

--- a/src/components/TabletFrame.tsx
+++ b/src/components/TabletFrame.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+interface TabletFrameProps {
+  children: React.ReactNode;
+}
+
+const TabletFrame: React.FC<TabletFrameProps> = ({ children }) => {
+  const backgroundClasses = "flex min-h-screen w-full items-center justify-center bg-gray-100 p-8";
+
+  // Original, smaller dimensions
+  const frameClasses = "relative mx-auto h-[768px] w-[1024px] rounded-[36px] border-[16px] border-black bg-black shadow-2xl";
+  const screenClasses = "relative h-full w-full overflow-hidden rounded-[20px] bg-white";
+
+  return (
+    <div className={backgroundClasses}>
+      <div className={frameClasses}>
+        {/* Front-facing camera */}
+        <div className="absolute top-1/2 left-[6px] z-10 h-[8px] w-[8px] -translate-y-1/2 rounded-full bg-gray-800"></div>
+
+        {/* Screen */}
+        <div className={screenClasses}>
+          <div className="h-full w-full overflow-y-auto">
+            {children}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TabletFrame;

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,6 +1,21 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
-import { ExternalLink, Users, Briefcase } from 'lucide-react';
+import { ArrowRight, Users, Shield, UserCheck } from 'lucide-react';
+
+const adminPages = [
+  { href: '/qo-a-001', title: 'QO-A001: Admin Dashboard' },
+  { href: '/qo-a-002', title: 'QO-A002: Multi-Location Management' },
+  { href: '/qo-a-003', title: 'QO-A003: Global Menu Management' },
+  { href: '/qo-a-004', title: 'QO-A004: Staff Management' },
+  { href: '/qo-a-005', title: 'QO-A005: Analytics & Reports' },
+  { href: '/qo-a-006', title: 'QO-A006: System Settings' },
+  { href: '/qo-a-007', title: 'QO-A007: Payment Management' },
+  { href: '/qo-a-008', title: 'QO-A008: Customer Management' },
+  { href: '/qo-a-009', title: 'QO-A009: Inventory Management' },
+  { href: '/qo-a-010', title: 'QO-A010: Promotion Management' },
+  { href: '/qo-a-011', title: 'QO-A011: Audit Logs' },
+  { href: '/qo-a-012', title: 'QO-A012: QR Code Management' },
+];
 
 const customerPages = [
   { href: '/qo-c-001', title: 'QO-C001: Landing Page' },
@@ -28,56 +43,93 @@ const PageLink: React.FC<{ href: string; title: string }> = ({ href, title }) =>
   <li className="mb-2">
     <Link
       to={href}
-      className="flex items-center justify-between p-3 bg-gray-50 hover:bg-gray-100 rounded-lg transition-colors duration-200"
+      className="flex items-center justify-between p-4 bg-gray-50 hover:bg-gray-100 rounded-lg transition-colors duration-200 group"
     >
-      <span className="font-medium text-gray-700">{title}</span>
-      <ExternalLink className="w-5 h-5 text-gray-400" />
+      <span className="font-medium text-gray-700 group-hover:text-purple-600">{title}</span>
+      <ArrowRight className="w-5 h-5 text-gray-400 group-hover:text-purple-600 transition-colors" />
     </Link>
   </li>
 );
 
+const TABS = [
+  {
+    id: 'admin',
+    name: 'Administrator',
+    icon: Shield,
+    pages: adminPages,
+    description: 'Explore the powerful, centralized dashboard for multi-location management, global menu configuration, and system-wide analytics. This journey is designed for business owners and administrators to monitor and control the entire operation.'
+  },
+  {
+    id: 'customer',
+    name: 'Customer Journey',
+    icon: Users,
+    pages: customerPages,
+    description: 'Experience the seamless customer flow from scanning a QR code to placing an order and making a payment. This journey showcases the intuitive, user-friendly interface that your customers will love.'
+  },
+  {
+    id: 'staff',
+    name: 'Staff Interface',
+    icon: UserCheck,
+    pages: staffPages,
+    description: 'See how your staff will manage orders, update table statuses, and interact with the kitchen display. This journey is optimized for efficiency and clear communication in a fast-paced restaurant environment.'
+  },
+];
+
 const HomePage: React.FC = () => {
+  const [activeTab, setActiveTab] = useState('admin');
+
+  const activeTabData = TABS.find(tab => tab.id === activeTab);
+
   return (
     <div className="bg-gray-50 min-h-screen">
-      <div className="max-w-4xl mx-auto py-12 px-4 sm:px-6 lg:px-8">
-        <div className="text-center">
-          <h1 className="text-4xl font-extrabold text-gray-900 sm:text-5xl md:text-6xl">
-            viatable
+      <div className="bg-gray-900 text-white">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16 text-center">
+          <h1 className="text-4xl font-extrabold sm:text-5xl md:text-6xl bg-gradient-to-r from-purple-400 to-pink-500 bg-clip-text text-transparent">
+            Interactive Product Showcase
           </h1>
-          <p className="mt-3 max-w-md mx-auto text-base text-gray-500 sm:text-lg md:mt-5 md:text-xl md:max-w-3xl">
-            viatable will be launched in December. Simultaneous service open in Korea/Australia.
-          </p>
-          <p className="mt-3 max-w-md mx-auto text-base text-gray-500 sm:text-lg md:mt-5 md:text-xl md:max-w-3xl">
-            (viatable 12월에 오픈 예정. 한국/호주 동시 서비스 오픈.)
+          <p className="mt-4 max-w-2xl mx-auto text-xl text-gray-300">
+            Explore the core user journeys of the VIATABLE platform. Click on any page to start an interactive, guided tour of our key features.
           </p>
         </div>
+      </div>
 
-        <div className="mt-16 grid gap-12 md:grid-cols-2">
-          {/* Customer Pages */}
-          <div className="bg-white p-6 rounded-xl shadow-md">
-            <h2 className="text-2xl font-bold text-gray-800 mb-4 flex items-center">
-              <Users className="w-7 h-7 mr-3 text-indigo-500" />
-              Customer Pages
-            </h2>
-            <ul>
-              {customerPages.map((page) => (
-                <PageLink key={page.href} {...page} />
-              ))}
-            </ul>
-          </div>
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        <div className="border-b border-gray-200 mb-8">
+          <nav className="-mb-px flex space-x-6" aria-label="Tabs">
+            {TABS.map((tab) => (
+              <button
+                key={tab.id}
+                onClick={() => setActiveTab(tab.id)}
+                className={`flex items-center space-x-2 whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm transition-colors ${
+                  activeTab === tab.id
+                    ? 'border-purple-500 text-purple-600'
+                    : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
+                }`}
+              >
+                <tab.icon className="w-5 h-5" />
+                <span>{tab.name}</span>
+              </button>
+            ))}
+          </nav>
+        </div>
 
-          {/* Staff Pages */}
-          <div className="bg-white p-6 rounded-xl shadow-md">
-            <h2 className="text-2xl font-bold text-gray-800 mb-4 flex items-center">
-              <Briefcase className="w-7 h-7 mr-3 text-green-500" />
-              Staff Pages
-            </h2>
-            <ul>
-              {staffPages.map((page) => (
-                <PageLink key={page.href} {...page} />
-              ))}
-            </ul>
-          </div>
+        <div>
+          {activeTabData && (
+            <div className="bg-white p-8 rounded-xl shadow-lg border border-gray-100">
+              <div className="mb-6">
+                <h2 className="text-3xl font-bold text-gray-800 mb-2 flex items-center">
+                  <activeTabData.icon className="w-8 h-8 mr-3 text-purple-500" />
+                  {activeTabData.name}
+                </h2>
+                <p className="text-gray-600">{activeTabData.description}</p>
+              </div>
+              <ul className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                {activeTabData.pages.map((page) => (
+                  <PageLink key={page.href} {...page} />
+                ))}
+              </ul>
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/src/pages/samples/admin/qo-a001-admin_dashboard.tsx
+++ b/src/pages/samples/admin/qo-a001-admin_dashboard.tsx
@@ -1,0 +1,314 @@
+import React, { useState } from 'react';
+import {
+  BarChart3, ShoppingCart, DollarSign,
+  Bell, Settings, Search, Store, Globe,
+  ArrowUpRight, ArrowDownRight, Star, AlertTriangle
+} from 'lucide-react';
+
+const AdminDashboard = () => {
+  const [selectedPeriod, setSelectedPeriod] = useState('today');
+  const [selectedLocation, setSelectedLocation] = useState('all');
+
+  // Mock data
+  const stats = {
+    totalRevenue: { value: '$48,532', change: '+12.5%', isPositive: true },
+    totalOrders: { value: '1,247', change: '+8.2%', isPositive: true },
+    avgOrderValue: { value: '$38.94', change: '-2.1%', isPositive: false },
+    activeLocations: { value: '12', change: '+1', isPositive: true }
+  };
+
+  const recentOrders = [
+    { id: '#ORD-2024-001', table: 'T-05', amount: '$45.80', status: 'completed', time: '2 min ago', location: 'Seoul Gangnam' },
+    { id: '#ORD-2024-002', table: 'T-12', amount: '$72.30', status: 'preparing', time: '5 min ago', location: 'Sydney CBD' },
+    { id: '#ORD-2024-003', table: 'T-08', amount: '$28.90', status: 'pending', time: '8 min ago', location: 'Seoul Hongdae' },
+    { id: '#ORD-2024-004', table: 'T-15', amount: '$91.20', status: 'completed', time: '12 min ago', location: 'Melbourne' },
+    { id: '#ORD-2024-005', table: 'T-03', amount: '$56.40', status: 'cancelled', time: '15 min ago', location: 'Sydney CBD' }
+  ];
+
+  const topLocations = [
+    { name: 'Seoul Gangnam', revenue: '$12,450', orders: 342, growth: '+15.2%' },
+    { name: 'Sydney CBD', revenue: '$11,280', orders: 298, growth: '+8.7%' },
+    { name: 'Seoul Hongdae', revenue: '$9,870', orders: 267, growth: '+12.1%' },
+    { name: 'Melbourne', revenue: '$8,920', orders: 234, growth: '+5.3%' },
+    { name: 'Brisbane', revenue: '$6,010', orders: 156, growth: '+18.9%' }
+  ];
+
+  const alerts = [
+    { type: 'warning', message: 'Seoul Hongdae: High wait times detected', time: '5 min ago' },
+    { type: 'info', message: 'Sydney CBD: New payment method configured', time: '15 min ago' },
+    { type: 'success', message: 'Melbourne: Daily revenue target achieved', time: '1 hour ago' }
+  ];
+
+  const getStatusColor = (status) => {
+    switch (status) {
+      case 'completed': return 'text-green-600 bg-green-50';
+      case 'preparing': return 'text-blue-600 bg-blue-50';
+      case 'pending': return 'text-yellow-600 bg-yellow-50';
+      case 'cancelled': return 'text-red-600 bg-red-50';
+      default: return 'text-gray-600 bg-gray-50';
+    }
+  };
+
+  const getAlertIcon = (type) => {
+    switch (type) {
+      case 'warning': return <AlertTriangle className="w-4 h-4 text-yellow-500" />;
+      case 'info': return <Bell className="w-4 h-4 text-blue-500" />;
+      case 'success': return <Star className="w-4 h-4 text-green-500" />;
+      default: return <Bell className="w-4 h-4 text-gray-500" />;
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      {/* Header */}
+      <header className="bg-white border-b border-gray-200">
+        <div className="px-6 py-4">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center space-x-4">
+              <h1 className="text-2xl font-bold text-gray-900">QR Order Admin</h1>
+              <div className="flex items-center space-x-2 text-sm text-gray-500">
+                <Globe className="w-4 h-4" />
+                <span>Global Dashboard</span>
+              </div>
+            </div>
+
+            <div className="flex items-center space-x-4">
+              <div className="relative">
+                <Search className="w-4 h-4 absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400" />
+                <input
+                  type="text"
+                  placeholder="Search orders, locations..."
+                  className="pl-9 pr-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                />
+              </div>
+
+              <select
+                value={selectedLocation}
+                onChange={(e) => setSelectedLocation(e.target.value)}
+                className="px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500"
+              >
+                <option value="all">All Locations</option>
+                <option value="seoul">Seoul</option>
+                <option value="sydney">Sydney</option>
+                <option value="melbourne">Melbourne</option>
+                <option value="brisbane">Brisbane</option>
+              </select>
+
+              <select
+                value={selectedPeriod}
+                onChange={(e) => setSelectedPeriod(e.target.value)}
+                className="px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500"
+              >
+                <option value="today">Today</option>
+                <option value="week">This Week</option>
+                <option value="month">This Month</option>
+                <option value="quarter">This Quarter</option>
+              </select>
+
+              <button className="p-2 text-gray-500 hover:text-gray-700 relative">
+                <Bell className="w-5 h-5" />
+                <span className="absolute -top-1 -right-1 w-3 h-3 bg-red-500 rounded-full"></span>
+              </button>
+
+              <button className="p-2 text-gray-500 hover:text-gray-700">
+                <Settings className="w-5 h-5" />
+              </button>
+            </div>
+          </div>
+        </div>
+      </header>
+
+      <div className="p-6">
+        {/* Key Metrics */}
+        <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-6 mb-8">
+          <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
+            <div className="flex items-center justify-between mb-4">
+              <div className="flex items-center space-x-3">
+                <div className="p-2 bg-green-100 rounded-lg">
+                  <DollarSign className="w-5 h-5 text-green-600" />
+                </div>
+                <div>
+                  <p className="text-sm font-medium text-gray-600">Total Revenue</p>
+                  <p className="text-2xl font-bold text-gray-900">{stats.totalRevenue.value}</p>
+                </div>
+              </div>
+              <div className={`flex items-center space-x-1 text-sm font-medium ${
+                stats.totalRevenue.isPositive ? 'text-green-600' : 'text-red-600'
+              }`}>
+                {stats.totalRevenue.isPositive ? <ArrowUpRight className="w-4 h-4" /> : <ArrowDownRight className="w-4 h-4" />}
+                <span>{stats.totalRevenue.change}</span>
+              </div>
+            </div>
+          </div>
+
+          <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
+            <div className="flex items-center justify-between mb-4">
+              <div className="flex items-center space-x-3">
+                <div className="p-2 bg-blue-100 rounded-lg">
+                  <ShoppingCart className="w-5 h-5 text-blue-600" />
+                </div>
+                <div>
+                  <p className="text-sm font-medium text-gray-600">Total Orders</p>
+                  <p className="text-2xl font-bold text-gray-900">{stats.totalOrders.value}</p>
+                </div>
+              </div>
+              <div className={`flex items-center space-x-1 text-sm font-medium ${
+                stats.totalOrders.isPositive ? 'text-green-600' : 'text-red-600'
+              }`}>
+                {stats.totalOrders.isPositive ? <ArrowUpRight className="w-4 h-4" /> : <ArrowDownRight className="w-4 h-4" />}
+                <span>{stats.totalOrders.change}</span>
+              </div>
+            </div>
+          </div>
+
+          <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
+            <div className="flex items-center justify-between mb-4">
+              <div className="flex items-center space-x-3">
+                <div className="p-2 bg-purple-100 rounded-lg">
+                  <BarChart3 className="w-5 h-5 text-purple-600" />
+                </div>
+                <div>
+                  <p className="text-sm font-medium text-gray-600">Avg Order Value</p>
+                  <p className="text-2xl font-bold text-gray-900">{stats.avgOrderValue.value}</p>
+                </div>
+              </div>
+              <div className={`flex items-center space-x-1 text-sm font-medium ${
+                stats.avgOrderValue.isPositive ? 'text-green-600' : 'text-red-600'
+              }`}>
+                {stats.avgOrderValue.isPositive ? <ArrowUpRight className="w-4 h-4" /> : <ArrowDownRight className="w-4 h-4" />}
+                <span>{stats.avgOrderValue.change}</span>
+              </div>
+            </div>
+          </div>
+
+          <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
+            <div className="flex items-center justify-between mb-4">
+              <div className="flex items-center space-x-3">
+                <div className="p-2 bg-orange-100 rounded-lg">
+                  <Store className="w-5 h-5 text-orange-600" />
+                </div>
+                <div>
+                  <p className="text-sm font-medium text-gray-600">Active Locations</p>
+                  <p className="text-2xl font-bold text-gray-900">{stats.activeLocations.value}</p>
+                </div>
+              </div>
+              <div className={`flex items-center space-x-1 text-sm font-medium ${
+                stats.activeLocations.isPositive ? 'text-green-600' : 'text-red-600'
+              }`}>
+                {stats.activeLocations.isPositive ? <ArrowUpRight className="w-4 h-4" /> : <ArrowDownRight className="w-4 h-4" />}
+                <span>{stats.activeLocations.change}</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+          {/* Recent Orders */}
+          <div className="lg:col-span-2 bg-white rounded-xl shadow-sm border border-gray-200">
+            <div className="p-6 border-b border-gray-200">
+              <div className="flex items-center justify-between">
+                <h3 className="text-lg font-semibold text-gray-900">Recent Orders</h3>
+                <button className="text-sm text-blue-600 hover:text-blue-700 font-medium">
+                  View All
+                </button>
+              </div>
+            </div>
+            <div className="overflow-hidden">
+              <table className="w-full">
+                <thead className="bg-gray-50">
+                  <tr>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Order ID</th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Table</th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Amount</th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Location</th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Time</th>
+                  </tr>
+                </thead>
+                <tbody className="bg-white divide-y divide-gray-200">
+                  {recentOrders.map((order) => (
+                    <tr key={order.id} className="hover:bg-gray-50">
+                      <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+                        {order.id}
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                        {order.table}
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+                        {order.amount}
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap">
+                        <span className={`inline-flex px-2 py-1 text-xs font-medium rounded-full ${getStatusColor(order.status)}`}>
+                          {order.status}
+                        </span>
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                        {order.location}
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                        {order.time}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+
+          {/* Alerts & Top Locations */}
+          <div className="space-y-6">
+            {/* Alerts */}
+            <div className="bg-white rounded-xl shadow-sm border border-gray-200">
+              <div className="p-6 border-b border-gray-200">
+                <h3 className="text-lg font-semibold text-gray-900">System Alerts</h3>
+              </div>
+              <div className="p-6">
+                <div className="space-y-4">
+                  {alerts.map((alert, index) => (
+                    <div key={index} className="flex items-start space-x-3">
+                      {getAlertIcon(alert.type)}
+                      <div className="flex-1 min-w-0">
+                        <p className="text-sm text-gray-900">{alert.message}</p>
+                        <p className="text-xs text-gray-500 mt-1">{alert.time}</p>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+
+            {/* Top Locations */}
+            <div className="bg-white rounded-xl shadow-sm border border-gray-200">
+              <div className="p-6 border-b border-gray-200">
+                <h3 className="text-lg font-semibold text-gray-900">Top Locations</h3>
+              </div>
+              <div className="p-6">
+                <div className="space-y-4">
+                  {topLocations.map((location, index) => (
+                    <div key={index} className="flex items-center justify-between">
+                      <div className="flex items-center space-x-3">
+                        <div className="w-8 h-8 bg-blue-100 rounded-full flex items-center justify-center">
+                          <span className="text-sm font-medium text-blue-600">{index + 1}</span>
+                        </div>
+                        <div>
+                          <p className="text-sm font-medium text-gray-900">{location.name}</p>
+                          <p className="text-xs text-gray-500">{location.orders} orders</p>
+                        </div>
+                      </div>
+                      <div className="text-right">
+                        <p className="text-sm font-medium text-gray-900">{location.revenue}</p>
+                        <p className="text-xs text-green-600">{location.growth}</p>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AdminDashboard;

--- a/src/pages/samples/admin/qo-a002-multi_location_management.tsx
+++ b/src/pages/samples/admin/qo-a002-multi_location_management.tsx
@@ -1,0 +1,472 @@
+import React, { useState } from 'react';
+import {
+  MapPin, Store, Plus, Wifi, Power,
+  Search, MoreVertical, Eye, Settings, TrendingUp, TrendingDown,
+  CheckCircle, XCircle, AlertTriangle
+} from 'lucide-react';
+
+const MultiLocationManagement = () => {
+  const [selectedView, setSelectedView] = useState('grid');
+  const [filterStatus, setFilterStatus] = useState('all');
+  const [filterRegion, setFilterRegion] = useState('all');
+  const [searchQuery, setSearchQuery] = useState('');
+  const [, setShowAddModal] = useState(false);
+
+  // Mock data for locations
+  const locations = [
+    {
+      id: 'LOC-001',
+      name: 'Seoul Gangnam',
+      address: '123 Gangnam-daero, Gangnam-gu, Seoul',
+      country: 'South Korea',
+      region: 'Korea',
+      status: 'active',
+      manager: 'Kim Minsoo',
+      phone: '+82-2-1234-5678',
+      email: 'gangnam@qrorder.com',
+      tables: 24,
+      staff: 12,
+      revenue: '$12,450',
+      orders: 342,
+      avgWaitTime: '8 min',
+      customerSatisfaction: 4.8,
+      lastOnline: '2 min ago',
+      openingHours: '11:00 - 22:00',
+      features: ['wifi', 'payment', 'kitchen_display'],
+      growth: '+15.2%',
+      isGrowthPositive: true
+    },
+    {
+      id: 'LOC-002',
+      name: 'Sydney CBD',
+      address: '456 George Street, Sydney NSW 2000',
+      country: 'Australia',
+      region: 'Australia',
+      status: 'active',
+      manager: 'Sarah Johnson',
+      phone: '+61-2-9876-5432',
+      email: 'sydney@qrorder.com',
+      tables: 18,
+      staff: 8,
+      revenue: '$11,280',
+      orders: 298,
+      avgWaitTime: '12 min',
+      customerSatisfaction: 4.6,
+      lastOnline: '1 min ago',
+      openingHours: '10:00 - 23:00',
+      features: ['wifi', 'payment'],
+      growth: '+8.7%',
+      isGrowthPositive: true
+    },
+    {
+      id: 'LOC-003',
+      name: 'Seoul Hongdae',
+      address: '789 Hongik-ro, Mapo-gu, Seoul',
+      country: 'South Korea',
+      region: 'Korea',
+      status: 'maintenance',
+      manager: 'Lee Jihoon',
+      phone: '+82-2-9876-5432',
+      email: 'hongdae@qrorder.com',
+      tables: 20,
+      staff: 10,
+      revenue: '$9,870',
+      orders: 267,
+      avgWaitTime: '18 min',
+      customerSatisfaction: 4.4,
+      lastOnline: '45 min ago',
+      openingHours: '12:00 - 02:00',
+      features: ['wifi'],
+      growth: '+12.1%',
+      isGrowthPositive: true
+    },
+    {
+      id: 'LOC-004',
+      name: 'Melbourne',
+      address: '321 Collins Street, Melbourne VIC 3000',
+      country: 'Australia',
+      region: 'Australia',
+      status: 'active',
+      manager: 'James Wilson',
+      phone: '+61-3-1234-5678',
+      email: 'melbourne@qrorder.com',
+      tables: 16,
+      staff: 7,
+      revenue: '$8,920',
+      orders: 234,
+      avgWaitTime: '10 min',
+      customerSatisfaction: 4.7,
+      lastOnline: '3 min ago',
+      openingHours: '11:00 - 22:30',
+      features: ['wifi', 'payment', 'kitchen_display'],
+      growth: '+5.3%',
+      isGrowthPositive: true
+    },
+    {
+      id: 'LOC-005',
+      name: 'Brisbane',
+      address: '654 Queen Street, Brisbane QLD 4000',
+      country: 'Australia',
+      region: 'Australia',
+      status: 'inactive',
+      manager: 'Emma Davis',
+      phone: '+61-7-8765-4321',
+      email: 'brisbane@qrorder.com',
+      tables: 14,
+      staff: 6,
+      revenue: '$6,010',
+      orders: 156,
+      avgWaitTime: '15 min',
+      customerSatisfaction: 4.2,
+      lastOnline: '2 days ago',
+      openingHours: '10:30 - 21:30',
+      features: ['wifi'],
+      growth: '+18.9%',
+      isGrowthPositive: true
+    }
+  ];
+
+  const getStatusColor = (status) => {
+    switch (status) {
+      case 'active': return 'text-green-600 bg-green-50 border-green-200';
+      case 'maintenance': return 'text-yellow-600 bg-yellow-50 border-yellow-200';
+      case 'inactive': return 'text-red-600 bg-red-50 border-red-200';
+      default: return 'text-gray-600 bg-gray-50 border-gray-200';
+    }
+  };
+
+  const getStatusIcon = (status) => {
+    switch (status) {
+      case 'active': return <CheckCircle className="w-4 h-4" />;
+      case 'maintenance': return <AlertTriangle className="w-4 h-4" />;
+      case 'inactive': return <XCircle className="w-4 h-4" />;
+      default: return <Power className="w-4 h-4" />;
+    }
+  };
+
+  const getFeatureIcon = (feature) => {
+    switch (feature) {
+      case 'wifi': return <Wifi className="w-4 h-4" />;
+      case 'payment': return <CheckCircle className="w-4 h-4" />;
+      case 'kitchen_display': return <Eye className="w-4 h-4" />;
+      default: return <Settings className="w-4 h-4" />;
+    }
+  };
+
+  const filteredLocations = locations.filter(location => {
+    const matchesSearch = location.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+                         location.address.toLowerCase().includes(searchQuery.toLowerCase()) ||
+                         location.manager.toLowerCase().includes(searchQuery.toLowerCase());
+    const matchesStatus = filterStatus === 'all' || location.status === filterStatus;
+    const matchesRegion = filterRegion === 'all' || location.region === filterRegion;
+
+    return matchesSearch && matchesStatus && matchesRegion;
+  });
+
+  const LocationCard = ({ location }) => (
+    <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6 hover:shadow-md transition-shadow">
+      {/* Header */}
+      <div className="flex items-start justify-between mb-4">
+        <div className="flex items-start space-x-3">
+          <div className="p-2 bg-blue-100 rounded-lg">
+            <Store className="w-5 h-5 text-blue-600" />
+          </div>
+          <div>
+            <h3 className="text-lg font-semibold text-gray-900">{location.name}</h3>
+            <p className="text-sm text-gray-500 flex items-center">
+              <MapPin className="w-3 h-3 mr-1" />
+              {location.address}
+            </p>
+          </div>
+        </div>
+        <div className="flex items-center space-x-2">
+          <div className={`flex items-center space-x-1 px-2 py-1 rounded-full border text-xs font-medium ${getStatusColor(location.status)}`}>
+            {getStatusIcon(location.status)}
+            <span className="capitalize">{location.status}</span>
+          </div>
+          <button className="p-1 text-gray-400 hover:text-gray-600">
+            <MoreVertical className="w-4 h-4" />
+          </button>
+        </div>
+      </div>
+
+      {/* Stats */}
+      <div className="grid grid-cols-2 gap-4 mb-4">
+        <div className="text-center p-3 bg-gray-50 rounded-lg">
+          <p className="text-lg font-bold text-gray-900">{location.revenue}</p>
+          <p className="text-xs text-gray-500">Today's Revenue</p>
+          <div className={`flex items-center justify-center space-x-1 text-xs font-medium mt-1 ${
+            location.isGrowthPositive ? 'text-green-600' : 'text-red-600'
+          }`}>
+            {location.isGrowthPositive ? <TrendingUp className="w-3 h-3" /> : <TrendingDown className="w-3 h-3" />}
+            <span>{location.growth}</span>
+          </div>
+        </div>
+        <div className="text-center p-3 bg-gray-50 rounded-lg">
+          <p className="text-lg font-bold text-gray-900">{location.orders}</p>
+          <p className="text-xs text-gray-500">Orders</p>
+          <p className="text-xs text-gray-500 mt-1">Avg wait: {location.avgWaitTime}</p>
+        </div>
+      </div>
+
+      {/* Details */}
+      <div className="space-y-2 text-sm">
+        <div className="flex items-center justify-between">
+          <span className="text-gray-500">Manager:</span>
+          <span className="font-medium text-gray-900">{location.manager}</span>
+        </div>
+        <div className="flex items-center justify-between">
+          <span className="text-gray-500">Tables:</span>
+          <span className="font-medium text-gray-900">{location.tables}</span>
+        </div>
+        <div className="flex items-center justify-between">
+          <span className="text-gray-500">Staff:</span>
+          <span className="font-medium text-gray-900">{location.staff}</span>
+        </div>
+        <div className="flex items-center justify-between">
+          <span className="text-gray-500">Rating:</span>
+          <div className="flex items-center space-x-1">
+            <span className="font-medium text-gray-900">{location.customerSatisfaction}</span>
+            <span className="text-yellow-400">★</span>
+          </div>
+        </div>
+        <div className="flex items-center justify-between">
+          <span className="text-gray-500">Last Online:</span>
+          <span className="font-medium text-gray-900">{location.lastOnline}</span>
+        </div>
+      </div>
+
+      {/* Features */}
+      <div className="mt-4 pt-4 border-t border-gray-100">
+        <div className="flex items-center justify-between">
+          <span className="text-sm text-gray-500">Features:</span>
+          <div className="flex items-center space-x-2">
+            {location.features.map((feature, index) => (
+              <div key={index} className="p-1 bg-blue-50 rounded text-blue-600" title={feature}>
+                {getFeatureIcon(feature)}
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Actions */}
+      <div className="mt-4 pt-4 border-t border-gray-100 flex space-x-2">
+        <button className="flex-1 px-3 py-2 text-sm bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors">
+          Manage
+        </button>
+        <button className="px-3 py-2 text-sm border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
+          View Details
+        </button>
+      </div>
+    </div>
+  );
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      {/* Header */}
+      <header className="bg-white border-b border-gray-200">
+        <div className="px-6 py-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <h1 className="text-2xl font-bold text-gray-900">Location Management</h1>
+              <p className="text-sm text-gray-500 mt-1">Manage all your restaurant locations</p>
+            </div>
+
+            <button
+              onClick={() => setShowAddModal(true)}
+              className="flex items-center space-x-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+            >
+              <Plus className="w-4 h-4" />
+              <span>Add Location</span>
+            </button>
+          </div>
+        </div>
+      </header>
+
+      <div className="p-6">
+        {/* Filters and Search */}
+        <div className="flex flex-col sm:flex-row gap-4 mb-6">
+          <div className="flex-1 relative">
+            <Search className="w-4 h-4 absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400" />
+            <input
+              type="text"
+              placeholder="Search locations, managers, addresses..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              className="w-full pl-9 pr-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            />
+          </div>
+
+          <select
+            value={filterRegion}
+            onChange={(e) => setFilterRegion(e.target.value)}
+            className="px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500"
+          >
+            <option value="all">All Regions</option>
+            <option value="Korea">Korea</option>
+            <option value="Australia">Australia</option>
+          </select>
+
+          <select
+            value={filterStatus}
+            onChange={(e) => setFilterStatus(e.target.value)}
+            className="px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500"
+          >
+            <option value="all">All Status</option>
+            <option value="active">Active</option>
+            <option value="maintenance">Maintenance</option>
+            <option value="inactive">Inactive</option>
+          </select>
+
+          <div className="flex border border-gray-300 rounded-lg">
+            <button
+              onClick={() => setSelectedView('grid')}
+              className={`px-3 py-2 text-sm font-medium ${
+                selectedView === 'grid'
+                  ? 'bg-blue-50 text-blue-600 border-r border-gray-300'
+                  : 'text-gray-500 hover:text-gray-700 border-r border-gray-300'
+              }`}
+            >
+              Grid
+            </button>
+            <button
+              onClick={() => setSelectedView('list')}
+              className={`px-3 py-2 text-sm font-medium ${
+                selectedView === 'list'
+                  ? 'bg-blue-50 text-blue-600'
+                  : 'text-gray-500 hover:text-gray-700'
+              }`}
+            >
+              List
+            </button>
+          </div>
+        </div>
+
+        {/* Summary Stats */}
+        <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-4 mb-6">
+          <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-4">
+            <div className="flex items-center space-x-3">
+              <div className="p-2 bg-green-100 rounded-lg">
+                <Store className="w-5 h-5 text-green-600" />
+              </div>
+              <div>
+                <p className="text-sm font-medium text-gray-600">Total Locations</p>
+                <p className="text-2xl font-bold text-gray-900">{locations.length}</p>
+              </div>
+            </div>
+          </div>
+
+          <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-4">
+            <div className="flex items-center space-x-3">
+              <div className="p-2 bg-blue-100 rounded-lg">
+                <CheckCircle className="w-5 h-5 text-blue-600" />
+              </div>
+              <div>
+                <p className="text-sm font-medium text-gray-600">Active</p>
+                <p className="text-2xl font-bold text-gray-900">
+                  {locations.filter(l => l.status === 'active').length}
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-4">
+            <div className="flex items-center space-x-3">
+              <div className="p-2 bg-yellow-100 rounded-lg">
+                <AlertTriangle className="w-5 h-5 text-yellow-600" />
+              </div>
+              <div>
+                <p className="text-sm font-medium text-gray-600">Maintenance</p>
+                <p className="text-2xl font-bold text-gray-900">
+                  {locations.filter(l => l.status === 'maintenance').length}
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-4">
+            <div className="flex items-center space-x-3">
+              <div className="p-2 bg-red-100 rounded-lg">
+                <XCircle className="w-5 h-5 text-red-600" />
+              </div>
+              <div>
+                <p className="text-sm font-medium text-gray-600">Inactive</p>
+                <p className="text-2xl font-bold text-gray-900">
+                  {locations.filter(l => l.status === 'inactive').length}
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Locations Grid/List */}
+        {selectedView === 'grid' ? (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {filteredLocations.map((location) => (
+              <LocationCard key={location.id} location={location} />
+            ))}
+          </div>
+        ) : (
+          <div className="bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden">
+            <table className="w-full">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Location</th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Manager</th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Performance</th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Last Online</th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
+                </tr>
+              </thead>
+              <tbody className="bg-white divide-y divide-gray-200">
+                {filteredLocations.map((location) => (
+                  <tr key={location.id} className="hover:bg-gray-50">
+                    <td className="px-6 py-4 whitespace-nowrap">
+                      <div className="flex items-center">
+                        <div className="p-2 bg-blue-100 rounded-lg mr-3">
+                          <Store className="w-4 h-4 text-blue-600" />
+                        </div>
+                        <div>
+                          <div className="text-sm font-medium text-gray-900">{location.name}</div>
+                          <div className="text-sm text-gray-500">{location.country}</div>
+                        </div>
+                      </div>
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap">
+                      <div className={`flex items-center space-x-1 px-2 py-1 rounded-full border text-xs font-medium ${getStatusColor(location.status)}`}>
+                        {getStatusIcon(location.status)}
+                        <span className="capitalize">{location.status}</span>
+                      </div>
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                      {location.manager}
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap">
+                      <div className="text-sm text-gray-900">{location.revenue}</div>
+                      <div className={`text-xs ${location.isGrowthPositive ? 'text-green-600' : 'text-red-600'}`}>
+                        {location.growth}
+                      </div>
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                      {location.lastOnline}
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm font-medium">
+                      <div className="flex space-x-2">
+                        <button className="text-blue-600 hover:text-blue-900">Edit</button>
+                        <button className="text-gray-600 hover:text-gray-900">View</button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default MultiLocationManagement;

--- a/src/pages/samples/admin/qo-a003-global_menu_management.tsx
+++ b/src/pages/samples/admin/qo-a003-global_menu_management.tsx
@@ -1,0 +1,544 @@
+import React, { useState } from 'react';
+import {
+  Plus, Search, Edit, Copy, Eye, EyeOff,
+  Upload, Download, Clock,
+  ChefHat, Star, AlertTriangle, CheckCircle,
+  MoreVertical, Users, TrendingUp
+} from 'lucide-react';
+
+const GlobalMenuManagement = () => {
+  const [selectedCategory, setSelectedCategory] = useState('all');
+  const [selectedLocation, setSelectedLocation] = useState('all');
+  const [selectedStatus, setSelectedStatus] = useState('all');
+  const [searchQuery, setSearchQuery] = useState('');
+  const [viewMode, setViewMode] = useState('grid');
+  const [, setShowAddModal] = useState(false);
+
+  // Mock data for menu items
+  const menuItems = [
+    {
+      id: 'MENU-001',
+      name: 'Korean BBQ Bulgogi',
+      nameKr: '불고기',
+      category: 'Main Course',
+      description: 'Marinated beef with Korean spices, served with rice and vegetables',
+      descriptionKr: '한국식 양념으로 재운 소고기, 밥과 채소와 함께 제공',
+      price: { kr: '₩18,000', au: '$24.50' },
+      image: '/api/placeholder/300/200',
+      status: 'active',
+      availability: {
+        'Seoul Gangnam': true,
+        'Seoul Hongdae': true,
+        'Sydney CBD': true,
+        'Melbourne': false,
+        'Brisbane': true
+      },
+      tags: ['popular', 'signature', 'korean'],
+      allergens: ['soy', 'gluten'],
+      dietary: ['gluten-free-option'],
+      prepTime: '15 min',
+      popularity: 4.8,
+      salesCount: 1247,
+      revenue: '$30,352',
+      lastUpdated: '2 hours ago',
+      createdBy: 'Chef Kim'
+    },
+    {
+      id: 'MENU-002',
+      name: 'Aussie Meat Pie',
+      nameKr: '호주식 미트파이',
+      category: 'Main Course',
+      description: 'Traditional Australian meat pie with beef mince and gravy',
+      descriptionKr: '소고기 다짐육과 그레이비가 들어간 전통 호주식 미트파이',
+      price: { kr: '₩12,000', au: '$16.50' },
+      image: '/api/placeholder/300/200',
+      status: 'active',
+      availability: {
+        'Seoul Gangnam': false,
+        'Seoul Hongdae': false,
+        'Sydney CBD': true,
+        'Melbourne': true,
+        'Brisbane': true
+      },
+      tags: ['australian', 'comfort-food'],
+      allergens: ['gluten', 'egg'],
+      dietary: [],
+      prepTime: '12 min',
+      popularity: 4.3,
+      salesCount: 892,
+      revenue: '$14,718',
+      lastUpdated: '1 day ago',
+      createdBy: 'Chef Wilson'
+    },
+    {
+      id: 'MENU-003',
+      name: 'Kimchi Fried Rice',
+      nameKr: '김치볶음밥',
+      category: 'Rice & Noodles',
+      description: 'Spicy kimchi fried rice with vegetables and choice of protein',
+      descriptionKr: '매콤한 김치볶음밥, 야채와 선택 가능한 단백질 포함',
+      price: { kr: '₩14,000', au: '$19.00' },
+      image: '/api/placeholder/300/200',
+      status: 'draft',
+      availability: {
+        'Seoul Gangnam': true,
+        'Seoul Hongdae': true,
+        'Sydney CBD': false,
+        'Melbourne': false,
+        'Brisbane': false
+      },
+      tags: ['korean', 'spicy', 'vegetarian-option'],
+      allergens: ['soy'],
+      dietary: ['vegetarian', 'vegan-option'],
+      prepTime: '10 min',
+      popularity: 4.6,
+      salesCount: 756,
+      revenue: '$10,584',
+      lastUpdated: '3 hours ago',
+      createdBy: 'Chef Lee'
+    },
+    {
+      id: 'MENU-004',
+      name: 'Fish & Chips',
+      nameKr: '피쉬 앤 칩스',
+      category: 'Main Course',
+      description: 'Beer-battered fish with crispy chips and mushy peas',
+      descriptionKr: '맥주 반죽으로 튀긴 생선과 바삭한 감자튀김, 으깬 완두콩',
+      price: { kr: '₩16,000', au: '$22.00' },
+      image: '/api/placeholder/300/200',
+      status: 'inactive',
+      availability: {
+        'Seoul Gangnam': false,
+        'Seoul Hongdae': false,
+        'Sydney CBD': true,
+        'Melbourne': true,
+        'Brisbane': true
+      },
+      tags: ['australian', 'seafood'],
+      allergens: ['fish', 'gluten'],
+      dietary: [],
+      prepTime: '18 min',
+      popularity: 4.1,
+      salesCount: 634,
+      revenue: '$13,948',
+      lastUpdated: '1 week ago',
+      createdBy: 'Chef Johnson'
+    },
+    {
+      id: 'MENU-005',
+      name: 'Bibimbap',
+      nameKr: '비빔밥',
+      category: 'Rice & Noodles',
+      description: 'Mixed rice bowl with assorted vegetables, meat, and gochujang',
+      descriptionKr: '다양한 채소와 고기, 고추장이 들어간 비빔밥',
+      price: { kr: '₩15,000', au: '$20.50' },
+      image: '/api/placeholder/300/200',
+      status: 'active',
+      availability: {
+        'Seoul Gangnam': true,
+        'Seoul Hongdae': true,
+        'Sydney CBD': true,
+        'Melbourne': true,
+        'Brisbane': false
+      },
+      tags: ['korean', 'healthy', 'colorful'],
+      allergens: ['soy', 'sesame'],
+      dietary: ['vegetarian-option', 'gluten-free-option'],
+      prepTime: '13 min',
+      popularity: 4.7,
+      salesCount: 1056,
+      revenue: '$21,648',
+      lastUpdated: '6 hours ago',
+      createdBy: 'Chef Park'
+    }
+  ];
+
+  const categories = ['All', 'Main Course', 'Rice & Noodles', 'Appetizers', 'Desserts', 'Beverages'];
+  const locations = ['All', 'Seoul Gangnam', 'Seoul Hongdae', 'Sydney CBD', 'Melbourne', 'Brisbane'];
+  const statuses = ['All', 'Active', 'Draft', 'Inactive'];
+
+  const getStatusColor = (status) => {
+    switch (status) {
+      case 'active': return 'text-green-600 bg-green-50 border-green-200';
+      case 'draft': return 'text-yellow-600 bg-yellow-50 border-yellow-200';
+      case 'inactive': return 'text-red-600 bg-red-50 border-red-200';
+      default: return 'text-gray-600 bg-gray-50 border-gray-200';
+    }
+  };
+
+  const getStatusIcon = (status) => {
+    switch (status) {
+      case 'active': return <CheckCircle className="w-4 h-4" />;
+      case 'draft': return <Edit className="w-4 h-4" />;
+      case 'inactive': return <EyeOff className="w-4 h-4" />;
+      default: return <AlertTriangle className="w-4 h-4" />;
+    }
+  };
+
+  const filteredItems = menuItems.filter(item => {
+    const matchesSearch = item.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+                         item.nameKr.includes(searchQuery) ||
+                         item.description.toLowerCase().includes(searchQuery.toLowerCase());
+    const matchesCategory = selectedCategory === 'all' || item.category === selectedCategory;
+    const matchesStatus = selectedStatus === 'all' || item.status === selectedStatus;
+    const matchesLocation = selectedLocation === 'all' || item.availability[selectedLocation];
+
+    return matchesSearch && matchesCategory && matchesStatus && matchesLocation;
+  });
+
+  const MenuCard = ({ item }) => {
+    const availableLocations = Object.entries(item.availability).filter(([, available]) => available).length;
+
+    return (
+      <div className="bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden hover:shadow-md transition-shadow">
+        {/* Image */}
+        <div className="relative h-48 bg-gray-100">
+          <img
+            src={item.image}
+            alt={item.name}
+            className="w-full h-full object-cover"
+          />
+          <div className="absolute top-3 left-3">
+            <div className={`flex items-center space-x-1 px-2 py-1 rounded-full border text-xs font-medium ${getStatusColor(item.status)}`}>
+              {getStatusIcon(item.status)}
+              <span className="capitalize">{item.status}</span>
+            </div>
+          </div>
+          <div className="absolute top-3 right-3">
+            <button className="p-1 bg-white rounded-full shadow-sm text-gray-600 hover:text-gray-800">
+              <MoreVertical className="w-4 h-4" />
+            </button>
+          </div>
+        </div>
+
+        {/* Content */}
+        <div className="p-4">
+          {/* Title and Category */}
+          <div className="mb-3">
+            <h3 className="text-lg font-semibold text-gray-900">{item.name}</h3>
+            <p className="text-sm text-gray-500">{item.nameKr}</p>
+            <span className="inline-block px-2 py-1 text-xs bg-blue-50 text-blue-600 rounded-full mt-1">
+              {item.category}
+            </span>
+          </div>
+
+          {/* Description */}
+          <p className="text-sm text-gray-600 mb-3 line-clamp-2">{item.description}</p>
+
+          {/* Price and Stats */}
+          <div className="grid grid-cols-2 gap-3 mb-3">
+            <div className="text-center p-2 bg-gray-50 rounded-lg">
+              <p className="text-sm font-bold text-gray-900">{item.price.kr}</p>
+              <p className="text-xs text-gray-500">Korea</p>
+            </div>
+            <div className="text-center p-2 bg-gray-50 rounded-lg">
+              <p className="text-sm font-bold text-gray-900">{item.price.au}</p>
+              <p className="text-xs text-gray-500">Australia</p>
+            </div>
+          </div>
+
+          {/* Performance */}
+          <div className="flex items-center justify-between mb-3 text-sm">
+            <div className="flex items-center space-x-1">
+              <Star className="w-4 h-4 text-yellow-400 fill-current" />
+              <span className="font-medium">{item.popularity}</span>
+            </div>
+            <div className="flex items-center space-x-1 text-gray-500">
+              <Users className="w-4 h-4" />
+              <span>{item.salesCount}</span>
+            </div>
+            <div className="flex items-center space-x-1 text-gray-500">
+              <Clock className="w-4 h-4" />
+              <span>{item.prepTime}</span>
+            </div>
+          </div>
+
+          {/* Availability */}
+          <div className="mb-3">
+            <div className="flex items-center justify-between text-sm mb-2">
+              <span className="text-gray-500">Available at:</span>
+              <span className="font-medium text-gray-900">{availableLocations}/5 locations</span>
+            </div>
+            <div className="flex flex-wrap gap-1">
+              {Object.entries(item.availability).map(([location, available]) => (
+                <span
+                  key={location}
+                  className={`text-xs px-2 py-1 rounded-full ${
+                    available
+                      ? 'bg-green-50 text-green-600'
+                      : 'bg-gray-50 text-gray-400'
+                  }`}
+                >
+                  {location.split(' ')[0]}
+                </span>
+              ))}
+            </div>
+          </div>
+
+          {/* Tags */}
+          <div className="mb-3">
+            <div className="flex flex-wrap gap-1">
+              {item.tags.slice(0, 3).map((tag, index) => (
+                <span key={index} className="text-xs px-2 py-1 bg-blue-50 text-blue-600 rounded-full">
+                  #{tag}
+                </span>
+              ))}
+              {item.tags.length > 3 && (
+                <span className="text-xs px-2 py-1 bg-gray-50 text-gray-500 rounded-full">
+                  +{item.tags.length - 3}
+                </span>
+              )}
+            </div>
+          </div>
+
+          {/* Actions */}
+          <div className="flex space-x-2">
+            <button className="flex-1 px-3 py-2 text-sm bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors">
+              Edit
+            </button>
+            <button className="px-3 py-2 text-sm border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
+              <Copy className="w-4 h-4" />
+            </button>
+            <button className="px-3 py-2 text-sm border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
+              <Eye className="w-4 h-4" />
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      {/* Header */}
+      <header className="bg-white border-b border-gray-200">
+        <div className="px-6 py-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <h1 className="text-2xl font-bold text-gray-900">Global Menu Management</h1>
+              <p className="text-sm text-gray-500 mt-1">Manage menu items across all locations</p>
+            </div>
+
+            <div className="flex items-center space-x-3">
+              <button className="flex items-center space-x-2 px-3 py-2 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
+                <Upload className="w-4 h-4" />
+                <span>Import</span>
+              </button>
+              <button className="flex items-center space-x-2 px-3 py-2 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
+                <Download className="w-4 h-4" />
+                <span>Export</span>
+              </button>
+              <button
+                onClick={() => setShowAddModal(true)}
+                className="flex items-center space-x-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+              >
+                <Plus className="w-4 h-4" />
+                <span>Add Item</span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </header>
+
+      <div className="p-6">
+        {/* Filters and Search */}
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 xl:grid-cols-6 gap-4 mb-6">
+          <div className="lg:col-span-2 relative">
+            <Search className="w-4 h-4 absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400" />
+            <input
+              type="text"
+              placeholder="Search menu items..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              className="w-full pl-9 pr-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            />
+          </div>
+
+          <select
+            value={selectedCategory}
+            onChange={(e) => setSelectedCategory(e.target.value)}
+            className="px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500"
+          >
+            {categories.map(cat => (
+              <option key={cat} value={cat.toLowerCase()}>{cat}</option>
+            ))}
+          </select>
+
+          <select
+            value={selectedLocation}
+            onChange={(e) => setSelectedLocation(e.target.value)}
+            className="px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500"
+          >
+            {locations.map(loc => (
+              <option key={loc} value={loc === 'All' ? 'all' : loc}>{loc}</option>
+            ))}
+          </select>
+
+          <select
+            value={selectedStatus}
+            onChange={(e) => setSelectedStatus(e.target.value)}
+            className="px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500"
+          >
+            {statuses.map(status => (
+              <option key={status} value={status.toLowerCase()}>{status}</option>
+            ))}
+          </select>
+
+          <div className="flex border border-gray-300 rounded-lg">
+            <button
+              onClick={() => setViewMode('grid')}
+              className={`flex-1 px-3 py-2 text-sm font-medium ${
+                viewMode === 'grid'
+                  ? 'bg-blue-50 text-blue-600 border-r border-gray-300'
+                  : 'text-gray-500 hover:text-gray-700 border-r border-gray-300'
+              }`}
+            >
+              Grid
+            </button>
+            <button
+              onClick={() => setViewMode('table')}
+              className={`flex-1 px-3 py-2 text-sm font-medium ${
+                viewMode === 'table'
+                  ? 'bg-blue-50 text-blue-600'
+                  : 'text-gray-500 hover:text-gray-700'
+              }`}
+            >
+              Table
+            </button>
+          </div>
+        </div>
+
+        {/* Summary Stats */}
+        <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-4 mb-6">
+          <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-4">
+            <div className="flex items-center space-x-3">
+              <div className="p-2 bg-blue-100 rounded-lg">
+                <ChefHat className="w-5 h-5 text-blue-600" />
+              </div>
+              <div>
+                <p className="text-sm font-medium text-gray-600">Total Items</p>
+                <p className="text-2xl font-bold text-gray-900">{menuItems.length}</p>
+              </div>
+            </div>
+          </div>
+
+          <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-4">
+            <div className="flex items-center space-x-3">
+              <div className="p-2 bg-green-100 rounded-lg">
+                <CheckCircle className="w-5 h-5 text-green-600" />
+              </div>
+              <div>
+                <p className="text-sm font-medium text-gray-600">Active</p>
+                <p className="text-2xl font-bold text-gray-900">
+                  {menuItems.filter(item => item.status === 'active').length}
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-4">
+            <div className="flex items-center space-x-3">
+              <div className="p-2 bg-yellow-100 rounded-lg">
+                <Edit className="w-5 h-5 text-yellow-600" />
+              </div>
+              <div>
+                <p className="text-sm font-medium text-gray-600">Draft</p>
+                <p className="text-2xl font-bold text-gray-900">
+                  {menuItems.filter(item => item.status === 'draft').length}
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-4">
+            <div className="flex items-center space-x-3">
+              <div className="p-2 bg-purple-100 rounded-lg">
+                <TrendingUp className="w-5 h-5 text-purple-600" />
+              </div>
+              <div>
+                <p className="text-sm font-medium text-gray-600">Avg Rating</p>
+                <p className="text-2xl font-bold text-gray-900">
+                  {(menuItems.reduce((sum, item) => sum + item.popularity, 0) / menuItems.length).toFixed(1)}
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Menu Items */}
+        {viewMode === 'grid' ? (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+            {filteredItems.map((item) => (
+              <MenuCard key={item.id} item={item} />
+            ))}
+          </div>
+        ) : (
+          <div className="bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden">
+            <table className="w-full">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Item</th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Category</th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Price</th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Availability</th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Performance</th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
+                </tr>
+              </thead>
+              <tbody className="bg-white divide-y divide-gray-200">
+                {filteredItems.map((item) => (
+                  <tr key={item.id} className="hover:bg-gray-50">
+                    <td className="px-6 py-4 whitespace-nowrap">
+                      <div className="flex items-center">
+                        <img className="h-10 w-10 rounded-lg object-cover mr-3" src={item.image} alt={item.name} />
+                        <div>
+                          <div className="text-sm font-medium text-gray-900">{item.name}</div>
+                          <div className="text-sm text-gray-500">{item.nameKr}</div>
+                        </div>
+                      </div>
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap">
+                      <span className="inline-block px-2 py-1 text-xs bg-blue-50 text-blue-600 rounded-full">
+                        {item.category}
+                      </span>
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                      <div>{item.price.kr}</div>
+                      <div className="text-gray-500">{item.price.au}</div>
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap">
+                      <div className={`flex items-center space-x-1 px-2 py-1 rounded-full border text-xs font-medium ${getStatusColor(item.status)}`}>
+                        {getStatusIcon(item.status)}
+                        <span className="capitalize">{item.status}</span>
+                      </div>
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                      {Object.entries(item.availability).filter(([, available]) => available).length}/5 locations
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                      <div className="flex items-center space-x-1">
+                        <Star className="w-3 h-3 text-yellow-400 fill-current" />
+                        <span>{item.popularity}</span>
+                      </div>
+                      <div className="text-gray-500">{item.salesCount} orders</div>
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm font-medium">
+                      <div className="flex space-x-2">
+                        <button className="text-blue-600 hover:text-blue-900">Edit</button>
+                        <button className="text-gray-600 hover:text-gray-900">Copy</button>
+                        <button className="text-red-600 hover:text-red-900">Delete</button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default GlobalMenuManagement;

--- a/src/pages/samples/admin/qo-a004-staff_management.tsx
+++ b/src/pages/samples/admin/qo-a004-staff_management.tsx
@@ -1,0 +1,551 @@
+import React, { useState } from 'react';
+import {
+  Users, Search, Eye, EyeOff,
+  Shield, Crown, User, Clock,
+  TrendingUp, AlertTriangle, CheckCircle,
+  MoreVertical, Key, UserPlus, Download, Upload
+} from 'lucide-react';
+
+const StaffManagement = () => {
+  const [selectedRole, setSelectedRole] = useState('all');
+  const [selectedLocation, setSelectedLocation] = useState('all');
+  const [selectedStatus, setSelectedStatus] = useState('all');
+  const [searchQuery, setSearchQuery] = useState('');
+  const [viewMode, setViewMode] = useState('grid');
+  const [, setShowAddModal] = useState(false);
+
+  // Mock data for staff members
+  const staffMembers = [
+    {
+      id: 'STAFF-001',
+      name: 'Kim Minsoo',
+      nameKr: '김민수',
+      email: 'minsoo.kim@qrorder.com',
+      phone: '+82-10-1234-5678',
+      role: 'manager',
+      location: 'Seoul Gangnam',
+      status: 'active',
+      avatar: '/api/placeholder/80/80',
+      hireDate: '2023-01-15',
+      lastLogin: '2 hours ago',
+      permissions: ['order_management', 'menu_edit', 'staff_view', 'analytics_view'],
+      performance: {
+        ordersHandled: 1247,
+        avgResponseTime: '2.3 min',
+        customerRating: 4.8,
+        efficiency: 95
+      },
+      workHours: '09:00 - 18:00',
+      department: 'Operations',
+      salary: '₩4,200,000',
+      emergencyContact: '+82-10-9876-5432'
+    },
+    {
+      id: 'STAFF-002',
+      name: 'Sarah Johnson',
+      nameKr: '사라 존슨',
+      email: 'sarah.johnson@qrorder.com',
+      phone: '+61-4-1234-5678',
+      role: 'admin',
+      location: 'Sydney CBD',
+      status: 'active',
+      avatar: '/api/placeholder/80/80',
+      hireDate: '2022-08-20',
+      lastLogin: '30 min ago',
+      permissions: ['full_access'],
+      performance: {
+        ordersHandled: 0,
+        avgResponseTime: '0 min',
+        customerRating: 0,
+        efficiency: 100
+      },
+      workHours: '08:00 - 17:00',
+      department: 'Administration',
+      salary: '$75,000',
+      emergencyContact: '+61-4-9876-5432'
+    },
+    {
+      id: 'STAFF-003',
+      name: 'Lee Jihoon',
+      nameKr: '이지훈',
+      email: 'jihoon.lee@qrorder.com',
+      phone: '+82-10-2345-6789',
+      role: 'staff',
+      location: 'Seoul Hongdae',
+      status: 'active',
+      avatar: '/api/placeholder/80/80',
+      hireDate: '2023-06-10',
+      lastLogin: '1 hour ago',
+      permissions: ['order_management', 'customer_service'],
+      performance: {
+        ordersHandled: 892,
+        avgResponseTime: '3.1 min',
+        customerRating: 4.6,
+        efficiency: 88
+      },
+      workHours: '14:00 - 23:00',
+      department: 'Service',
+      salary: '₩3,200,000',
+      emergencyContact: '+82-10-8765-4321'
+    },
+    {
+      id: 'STAFF-004',
+      name: 'James Wilson',
+      nameKr: '제임스 윌슨',
+      email: 'james.wilson@qrorder.com',
+      phone: '+61-4-3456-7890',
+      role: 'manager',
+      location: 'Melbourne',
+      status: 'inactive',
+      avatar: '/api/placeholder/80/80',
+      hireDate: '2022-11-05',
+      lastLogin: '3 days ago',
+      permissions: ['order_management', 'menu_edit', 'staff_view', 'analytics_view'],
+      performance: {
+        ordersHandled: 756,
+        avgResponseTime: '2.8 min',
+        customerRating: 4.4,
+        efficiency: 82
+      },
+      workHours: '10:00 - 19:00',
+      department: 'Operations',
+      salary: '$68,000',
+      emergencyContact: '+61-4-7654-3210'
+    },
+    {
+      id: 'STAFF-005',
+      name: 'Emma Davis',
+      nameKr: '엠마 데이비스',
+      email: 'emma.davis@qrorder.com',
+      phone: '+61-4-4567-8901',
+      role: 'staff',
+      location: 'Brisbane',
+      status: 'on_leave',
+      avatar: '/api/placeholder/80/80',
+      hireDate: '2023-03-22',
+      lastLogin: '1 week ago',
+      permissions: ['order_management', 'customer_service'],
+      performance: {
+        ordersHandled: 634,
+        avgResponseTime: '3.5 min',
+        customerRating: 4.2,
+        efficiency: 78
+      },
+      workHours: '11:00 - 20:00',
+      department: 'Service',
+      salary: '$52,000',
+      emergencyContact: '+61-4-6543-2109'
+    }
+  ];
+
+  const roles = ['All', 'Admin', 'Manager', 'Staff'];
+  const locations = ['All', 'Seoul Gangnam', 'Seoul Hongdae', 'Sydney CBD', 'Melbourne', 'Brisbane'];
+  const statuses = ['All', 'Active', 'Inactive', 'On Leave'];
+
+  const getRoleColor = (role) => {
+    switch (role) {
+      case 'admin': return 'text-purple-600 bg-purple-50 border-purple-200';
+      case 'manager': return 'text-blue-600 bg-blue-50 border-blue-200';
+      case 'staff': return 'text-green-600 bg-green-50 border-green-200';
+      default: return 'text-gray-600 bg-gray-50 border-gray-200';
+    }
+  };
+
+  const getRoleIcon = (role) => {
+    switch (role) {
+      case 'admin': return <Crown className="w-4 h-4" />;
+      case 'manager': return <Shield className="w-4 h-4" />;
+      case 'staff': return <User className="w-4 h-4" />;
+      default: return <User className="w-4 h-4" />;
+    }
+  };
+
+  const getStatusColor = (status) => {
+    switch (status) {
+      case 'active': return 'text-green-600 bg-green-50 border-green-200';
+      case 'inactive': return 'text-red-600 bg-red-50 border-red-200';
+      case 'on_leave': return 'text-yellow-600 bg-yellow-50 border-yellow-200';
+      default: return 'text-gray-600 bg-gray-50 border-gray-200';
+    }
+  };
+
+  const getStatusIcon = (status) => {
+    switch (status) {
+      case 'active': return <CheckCircle className="w-4 h-4" />;
+      case 'inactive': return <EyeOff className="w-4 h-4" />;
+      case 'on_leave': return <Clock className="w-4 h-4" />;
+      default: return <AlertTriangle className="w-4 h-4" />;
+    }
+  };
+
+  const filteredStaff = staffMembers.filter(staff => {
+    const matchesSearch = staff.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+                         staff.nameKr.includes(searchQuery) ||
+                         staff.email.toLowerCase().includes(searchQuery.toLowerCase());
+    const matchesRole = selectedRole === 'all' || staff.role === selectedRole.toLowerCase();
+    const matchesLocation = selectedLocation === 'all' || staff.location === selectedLocation;
+    const matchesStatus = selectedStatus === 'all' || staff.status === selectedStatus.toLowerCase().replace(' ', '_');
+
+    return matchesSearch && matchesRole && matchesLocation && matchesStatus;
+  });
+
+  const StaffCard = ({ staff }) => (
+    <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6 hover:shadow-md transition-shadow">
+      {/* Header */}
+      <div className="flex items-start justify-between mb-4">
+        <div className="flex items-start space-x-3">
+          <img
+            src={staff.avatar}
+            alt={staff.name}
+            className="w-12 h-12 rounded-full object-cover border-2 border-gray-200"
+          />
+          <div>
+            <h3 className="text-lg font-semibold text-gray-900">{staff.name}</h3>
+            <p className="text-sm text-gray-500">{staff.nameKr}</p>
+            <p className="text-sm text-gray-500">{staff.email}</p>
+          </div>
+        </div>
+        <button className="p-1 text-gray-400 hover:text-gray-600">
+          <MoreVertical className="w-4 h-4" />
+        </button>
+      </div>
+
+      {/* Role and Status */}
+      <div className="flex items-center space-x-2 mb-4">
+        <div className={`flex items-center space-x-1 px-2 py-1 rounded-full border text-xs font-medium ${getRoleColor(staff.role)}`}>
+          {getRoleIcon(staff.role)}
+          <span className="capitalize">{staff.role}</span>
+        </div>
+        <div className={`flex items-center space-x-1 px-2 py-1 rounded-full border text-xs font-medium ${getStatusColor(staff.status)}`}>
+          {getStatusIcon(staff.status)}
+          <span className="capitalize">{staff.status.replace('_', ' ')}</span>
+        </div>
+      </div>
+
+      {/* Performance Stats */}
+      <div className="grid grid-cols-2 gap-3 mb-4">
+        <div className="text-center p-3 bg-gray-50 rounded-lg">
+          <p className="text-lg font-bold text-gray-900">{staff.performance.ordersHandled}</p>
+          <p className="text-xs text-gray-500">Orders Handled</p>
+        </div>
+        <div className="text-center p-3 bg-gray-50 rounded-lg">
+          <p className="text-lg font-bold text-gray-900">{staff.performance.customerRating}</p>
+          <p className="text-xs text-gray-500">Rating</p>
+        </div>
+      </div>
+
+      {/* Details */}
+      <div className="space-y-2 text-sm mb-4">
+        <div className="flex items-center justify-between">
+          <span className="text-gray-500">Location:</span>
+          <span className="font-medium text-gray-900">{staff.location}</span>
+        </div>
+        <div className="flex items-center justify-between">
+          <span className="text-gray-500">Department:</span>
+          <span className="font-medium text-gray-900">{staff.department}</span>
+        </div>
+        <div className="flex items-center justify-between">
+          <span className="text-gray-500">Work Hours:</span>
+          <span className="font-medium text-gray-900">{staff.workHours}</span>
+        </div>
+        <div className="flex items-center justify-between">
+          <span className="text-gray-500">Hire Date:</span>
+          <span className="font-medium text-gray-900">{new Date(staff.hireDate).toLocaleDateString()}</span>
+        </div>
+        <div className="flex items-center justify-between">
+          <span className="text-gray-500">Last Login:</span>
+          <span className="font-medium text-gray-900">{staff.lastLogin}</span>
+        </div>
+      </div>
+
+      {/* Performance Bar */}
+      <div className="mb-4">
+        <div className="flex items-center justify-between text-sm mb-1">
+          <span className="text-gray-500">Efficiency</span>
+          <span className="font-medium text-gray-900">{staff.performance.efficiency}%</span>
+        </div>
+        <div className="w-full bg-gray-200 rounded-full h-2">
+          <div
+            className="bg-blue-600 h-2 rounded-full transition-all duration-300"
+            style={{ width: `${staff.performance.efficiency}%` }}
+          ></div>
+        </div>
+      </div>
+
+      {/* Permissions */}
+      <div className="mb-4">
+        <span className="text-sm text-gray-500 mb-2 block">Permissions:</span>
+        <div className="flex flex-wrap gap-1">
+          {staff.permissions.slice(0, 3).map((permission, index) => (
+            <span key={index} className="text-xs px-2 py-1 bg-blue-50 text-blue-600 rounded-full">
+              {permission.replace('_', ' ')}
+            </span>
+          ))}
+          {staff.permissions.length > 3 && (
+            <span className="text-xs px-2 py-1 bg-gray-50 text-gray-500 rounded-full">
+              +{staff.permissions.length - 3}
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Actions */}
+      <div className="flex space-x-2">
+        <button className="flex-1 px-3 py-2 text-sm bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors">
+          Edit
+        </button>
+        <button className="px-3 py-2 text-sm border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
+          <Eye className="w-4 h-4" />
+        </button>
+        <button className="px-3 py-2 text-sm border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
+          <Key className="w-4 h-4" />
+        </button>
+      </div>
+    </div>
+  );
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      {/* Header */}
+      <header className="bg-white border-b border-gray-200">
+        <div className="px-6 py-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <h1 className="text-2xl font-bold text-gray-900">Staff Management</h1>
+              <p className="text-sm text-gray-500 mt-1">Manage staff accounts and permissions</p>
+            </div>
+
+            <div className="flex items-center space-x-3">
+              <button className="flex items-center space-x-2 px-3 py-2 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
+                <Upload className="w-4 h-4" />
+                <span>Import</span>
+              </button>
+              <button className="flex items-center space-x-2 px-3 py-2 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
+                <Download className="w-4 h-4" />
+                <span>Export</span>
+              </button>
+              <button
+                onClick={() => setShowAddModal(true)}
+                className="flex items-center space-x-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+              >
+                <UserPlus className="w-4 h-4" />
+                <span>Add Staff</span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </header>
+
+      <div className="p-6">
+        {/* Filters and Search */}
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 xl:grid-cols-6 gap-4 mb-6">
+          <div className="lg:col-span-2 relative">
+            <Search className="w-4 h-4 absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400" />
+            <input
+              type="text"
+              placeholder="Search staff members..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              className="w-full pl-9 pr-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            />
+          </div>
+
+          <select
+            value={selectedRole}
+            onChange={(e) => setSelectedRole(e.target.value)}
+            className="px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500"
+          >
+            {roles.map(role => (
+              <option key={role} value={role.toLowerCase()}>{role}</option>
+            ))}
+          </select>
+
+          <select
+            value={selectedLocation}
+            onChange={(e) => setSelectedLocation(e.target.value)}
+            className="px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500"
+          >
+            {locations.map(loc => (
+              <option key={loc} value={loc === 'All' ? 'all' : loc}>{loc}</option>
+            ))}
+          </select>
+
+          <select
+            value={selectedStatus}
+            onChange={(e) => setSelectedStatus(e.target.value)}
+            className="px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500"
+          >
+            {statuses.map(status => (
+              <option key={status} value={status.toLowerCase()}>{status}</option>
+            ))}
+          </select>
+
+          <div className="flex border border-gray-300 rounded-lg">
+            <button
+              onClick={() => setViewMode('grid')}
+              className={`flex-1 px-3 py-2 text-sm font-medium ${
+                viewMode === 'grid'
+                  ? 'bg-blue-50 text-blue-600 border-r border-gray-300'
+                  : 'text-gray-500 hover:text-gray-700 border-r border-gray-300'
+              }`}
+            >
+              Grid
+            </button>
+            <button
+              onClick={() => setViewMode('table')}
+              className={`flex-1 px-3 py-2 text-sm font-medium ${
+                viewMode === 'table'
+                  ? 'bg-blue-50 text-blue-600'
+                  : 'text-gray-500 hover:text-gray-700'
+              }`}
+            >
+              Table
+            </button>
+          </div>
+        </div>
+
+        {/* Summary Stats */}
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5 gap-4 mb-6">
+          <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-4">
+            <div className="flex items-center space-x-3">
+              <div className="p-2 bg-blue-100 rounded-lg">
+                <Users className="w-5 h-5 text-blue-600" />
+              </div>
+              <div>
+                <p className="text-sm font-medium text-gray-600">Total Staff</p>
+                <p className="text-2xl font-bold text-gray-900">{staffMembers.length}</p>
+              </div>
+            </div>
+          </div>
+
+          <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-4">
+            <div className="flex items-center space-x-3">
+              <div className="p-2 bg-green-100 rounded-lg">
+                <CheckCircle className="w-5 h-5 text-green-600" />
+              </div>
+              <div>
+                <p className="text-sm font-medium text-gray-600">Active</p>
+                <p className="text-2xl font-bold text-gray-900">
+                  {staffMembers.filter(s => s.status === 'active').length}
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-4">
+            <div className="flex items-center space-x-3">
+              <div className="p-2 bg-purple-100 rounded-lg">
+                <Crown className="w-5 h-5 text-purple-600" />
+              </div>
+              <div>
+                <p className="text-sm font-medium text-gray-600">Admins</p>
+                <p className="text-2xl font-bold text-gray-900">
+                  {staffMembers.filter(s => s.role === 'admin').length}
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-4">
+            <div className="flex items-center space-x-3">
+              <div className="p-2 bg-orange-100 rounded-lg">
+                <Shield className="w-5 h-5 text-orange-600" />
+              </div>
+              <div>
+                <p className="text-sm font-medium text-gray-600">Managers</p>
+                <p className="text-2xl font-bold text-gray-900">
+                  {staffMembers.filter(s => s.role === 'manager').length}
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-4">
+            <div className="flex items-center space-x-3">
+              <div className="p-2 bg-yellow-100 rounded-lg">
+                <TrendingUp className="w-5 h-5 text-yellow-600" />
+              </div>
+              <div>
+                <p className="text-sm font-medium text-gray-600">Avg Efficiency</p>
+                <p className="text-2xl font-bold text-gray-900">
+                  {Math.round(staffMembers.reduce((sum, s) => sum + s.performance.efficiency, 0) / staffMembers.length)}%
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Staff Members */}
+        {viewMode === 'grid' ? (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {filteredStaff.map((staff) => (
+              <StaffCard key={staff.id} staff={staff} />
+            ))}
+          </div>
+        ) : (
+          <div className="bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden">
+            <table className="w-full">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Staff</th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Role</th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Location</th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Performance</th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Last Login</th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
+                </tr>
+              </thead>
+              <tbody className="bg-white divide-y divide-gray-200">
+                {filteredStaff.map((staff) => (
+                  <tr key={staff.id} className="hover:bg-gray-50">
+                    <td className="px-6 py-4 whitespace-nowrap">
+                      <div className="flex items-center">
+                        <img className="h-10 w-10 rounded-full object-cover mr-3" src={staff.avatar} alt={staff.name} />
+                        <div>
+                          <div className="text-sm font-medium text-gray-900">{staff.name}</div>
+                          <div className="text-sm text-gray-500">{staff.email}</div>
+                        </div>
+                      </div>
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap">
+                      <div className={`flex items-center space-x-1 px-2 py-1 rounded-full border text-xs font-medium ${getRoleColor(staff.role)}`}>
+                        {getRoleIcon(staff.role)}
+                        <span className="capitalize">{staff.role}</span>
+                      </div>
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                      {staff.location}
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap">
+                      <div className={`flex items-center space-x-1 px-2 py-1 rounded-full border text-xs font-medium ${getStatusColor(staff.status)}`}>
+                        {getStatusIcon(staff.status)}
+                        <span className="capitalize">{staff.status.replace('_', ' ')}</span>
+                      </div>
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                      <div>{staff.performance.efficiency}%</div>
+                      <div className="text-gray-500">{staff.performance.customerRating}★</div>
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                      {staff.lastLogin}
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm font-medium">
+                      <div className="flex space-x-2">
+                        <button className="text-blue-600 hover:text-blue-900">Edit</button>
+                        <button className="text-gray-600 hover:text-gray-900">View</button>
+                        <button className="text-orange-600 hover:text-orange-900">Permissions</button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default StaffManagement;

--- a/src/pages/samples/admin/qo-a005-analytics_reports.tsx
+++ b/src/pages/samples/admin/qo-a005-analytics_reports.tsx
@@ -1,0 +1,516 @@
+import React, { useState } from 'react';
+import {
+  BarChart3, TrendingUp, DollarSign, Users, Clock,
+  Download, RefreshCw, Share,
+  Activity, Target, Award, MapPin, ShoppingCart,
+  Star, Utensils, ArrowUpRight,
+  ArrowDownRight, AlertTriangle
+} from 'lucide-react';
+
+const AnalyticsReports = () => {
+  const [selectedPeriod, setSelectedPeriod] = useState('7days');
+  const [selectedLocation, setSelectedLocation] = useState('all');
+  const [selectedReport, setSelectedReport] = useState('overview');
+  const [isLoading, setIsLoading] = useState(false);
+
+  // Mock data for analytics
+  const analyticsData = {
+    overview: {
+      totalRevenue: { value: '$248,532', change: '+12.5%', isPositive: true },
+      totalOrders: { value: '8,247', change: '+8.2%', isPositive: true },
+      avgOrderValue: { value: '$30.14', change: '-2.1%', isPositive: false },
+      customerSatisfaction: { value: '4.6', change: '+0.3', isPositive: true }
+    },
+    revenueChart: [
+      { date: '2024-01-01', revenue: 12450, orders: 342 },
+      { date: '2024-01-02', revenue: 13280, orders: 365 },
+      { date: '2024-01-03', revenue: 11870, orders: 298 },
+      { date: '2024-01-04', revenue: 15420, orders: 412 },
+      { date: '2024-01-05', revenue: 14630, orders: 387 },
+      { date: '2024-01-06', revenue: 16890, orders: 445 },
+      { date: '2024-01-07', revenue: 18920, orders: 478 }
+    ],
+    topLocations: [
+      { name: 'Seoul Gangnam', revenue: '$52,450', orders: 1342, growth: '+15.2%', efficiency: 95 },
+      { name: 'Sydney CBD', revenue: '$48,280', orders: 1298, growth: '+8.7%', efficiency: 92 },
+      { name: 'Seoul Hongdae', revenue: '$42,870', orders: 1167, growth: '+12.1%', efficiency: 88 },
+      { name: 'Melbourne', revenue: '$38,920', orders: 1034, growth: '+5.3%', efficiency: 85 },
+      { name: 'Brisbane', revenue: '$26,010', orders: 756, growth: '+18.9%', efficiency: 82 }
+    ],
+    topMenuItems: [
+      { name: 'Korean BBQ Bulgogi', sales: 1247, revenue: '$30,352', rating: 4.8, trend: '+12%' },
+      { name: 'Bibimbap', sales: 1056, revenue: '$21,648', rating: 4.7, trend: '+8%' },
+      { name: 'Aussie Meat Pie', sales: 892, revenue: '$14,718', rating: 4.3, trend: '+5%' },
+      { name: 'Kimchi Fried Rice', sales: 756, revenue: '$10,584', rating: 4.6, trend: '+15%' },
+      { name: 'Fish & Chips', sales: 634, revenue: '$13,948', rating: 4.1, trend: '-3%' }
+    ],
+    customerMetrics: {
+      newCustomers: { value: '1,247', change: '+23%', isPositive: true },
+      returningCustomers: { value: '3,892', change: '+15%', isPositive: true },
+      avgSessionTime: { value: '24 min', change: '+5%', isPositive: true },
+      bounceRate: { value: '12%', change: '-8%', isPositive: true }
+    },
+    peakHours: [
+      { hour: '11:00', orders: 45, efficiency: 85 },
+      { hour: '12:00', orders: 78, efficiency: 92 },
+      { hour: '13:00', orders: 95, efficiency: 88 },
+      { hour: '18:00', orders: 112, efficiency: 94 },
+      { hour: '19:00', orders: 134, efficiency: 96 },
+      { hour: '20:00', orders: 98, efficiency: 91 }
+    ]
+  };
+
+  const reportTypes = [
+    { id: 'overview', name: 'Overview', icon: BarChart3 },
+    { id: 'revenue', name: 'Revenue Analysis', icon: DollarSign },
+    { id: 'customer', name: 'Customer Insights', icon: Users },
+    { id: 'menu', name: 'Menu Performance', icon: Utensils },
+    { id: 'operational', name: 'Operational Metrics', icon: Activity },
+    { id: 'comparative', name: 'Location Comparison', icon: MapPin }
+  ];
+
+  const periods = [
+    { value: '24hours', label: 'Last 24 Hours' },
+    { value: '7days', label: 'Last 7 Days' },
+    { value: '30days', label: 'Last 30 Days' },
+    { value: '90days', label: 'Last 90 Days' },
+    { value: 'custom', label: 'Custom Range' }
+  ];
+
+  const locations = [
+    { value: 'all', label: 'All Locations' },
+    { value: 'seoul', label: 'Seoul (All)' },
+    { value: 'australia', label: 'Australia (All)' },
+    { value: 'seoul_gangnam', label: 'Seoul Gangnam' },
+    { value: 'seoul_hongdae', label: 'Seoul Hongdae' },
+    { value: 'sydney_cbd', label: 'Sydney CBD' },
+    { value: 'melbourne', label: 'Melbourne' },
+    { value: 'brisbane', label: 'Brisbane' }
+  ];
+
+  const handleRefresh = () => {
+    setIsLoading(true);
+    setTimeout(() => setIsLoading(false), 1500);
+  };
+
+  const MetricCard = ({ title, value, change, icon: Icon, isPositive }) => (
+    <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center space-x-3">
+          <div className="p-2 bg-blue-100 rounded-lg">
+            <Icon className="w-5 h-5 text-blue-600" />
+          </div>
+          <div>
+            <p className="text-sm font-medium text-gray-600">{title}</p>
+            <p className="text-2xl font-bold text-gray-900">{value}</p>
+          </div>
+        </div>
+        <div className={`flex items-center space-x-1 text-sm font-medium ${
+          isPositive ? 'text-green-600' : 'text-red-600'
+        }`}>
+          {isPositive ? <ArrowUpRight className="w-4 h-4" /> : <ArrowDownRight className="w-4 h-4" />}
+          <span>{change}</span>
+        </div>
+      </div>
+    </div>
+  );
+
+  const RevenueChart = () => (
+    <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
+      <div className="flex items-center justify-between mb-6">
+        <h3 className="text-lg font-semibold text-gray-900">Revenue Trend</h3>
+        <div className="flex items-center space-x-2">
+          <span className="text-sm text-gray-500">Revenue</span>
+          <div className="w-3 h-3 bg-blue-600 rounded-full"></div>
+          <span className="text-sm text-gray-500">Orders</span>
+          <div className="w-3 h-3 bg-green-600 rounded-full"></div>
+        </div>
+      </div>
+      <div className="h-64 relative">
+        <svg className="w-full h-full" viewBox="0 0 400 200">
+          {/* Revenue line */}
+          <polyline
+            fill="none"
+            stroke="#2563eb"
+            strokeWidth="3"
+            points="20,150 80,130 140,160 200,100 260,110 320,80 380,60"
+          />
+          {/* Orders line */}
+          <polyline
+            fill="none"
+            stroke="#16a34a"
+            strokeWidth="3"
+            points="20,120 80,110 140,130 200,85 260,95 320,70 380,50"
+          />
+          {/* Data points */}
+          {analyticsData.revenueChart.map((point, index) => (
+            <g key={index}>
+              <circle cx={20 + index * 60} cy={150 - (point.revenue / 200)} r="4" fill="#2563eb" />
+              <circle cx={20 + index * 60} cy={120 - (point.orders / 5)} r="4" fill="#16a34a" />
+            </g>
+          ))}
+        </svg>
+        <div className="absolute bottom-0 left-0 right-0 flex justify-between text-xs text-gray-500 px-2">
+          {analyticsData.revenueChart.map((point, index) => (
+            <span key={index}>{new Date(point.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}</span>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+
+  const TopLocationsTable = () => (
+    <div className="bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden">
+      <div className="p-6 border-b border-gray-200">
+        <h3 className="text-lg font-semibold text-gray-900">Location Performance</h3>
+      </div>
+      <div className="overflow-x-auto">
+        <table className="w-full">
+          <thead className="bg-gray-50">
+            <tr>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Location</th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Revenue</th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Orders</th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Growth</th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Efficiency</th>
+            </tr>
+          </thead>
+          <tbody className="bg-white divide-y divide-gray-200">
+            {analyticsData.topLocations.map((location, index) => (
+              <tr key={index} className="hover:bg-gray-50">
+                <td className="px-6 py-4 whitespace-nowrap">
+                  <div className="flex items-center">
+                    <div className="w-8 h-8 bg-blue-100 rounded-full flex items-center justify-center mr-3">
+                      <span className="text-sm font-medium text-blue-600">{index + 1}</span>
+                    </div>
+                    <div>
+                      <div className="text-sm font-medium text-gray-900">{location.name}</div>
+                    </div>
+                  </div>
+                </td>
+                <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+                  {location.revenue}
+                </td>
+                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                  {location.orders}
+                </td>
+                <td className="px-6 py-4 whitespace-nowrap">
+                  <span className="text-sm font-medium text-green-600">{location.growth}</span>
+                </td>
+                <td className="px-6 py-4 whitespace-nowrap">
+                  <div className="flex items-center">
+                    <div className="w-16 bg-gray-200 rounded-full h-2 mr-2">
+                      <div
+                        className="bg-blue-600 h-2 rounded-full"
+                        style={{ width: `${location.efficiency}%` }}
+                      ></div>
+                    </div>
+                    <span className="text-sm text-gray-900">{location.efficiency}%</span>
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+
+  const TopMenuItems = () => (
+    <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
+      <div className="flex items-center justify-between mb-6">
+        <h3 className="text-lg font-semibold text-gray-900">Top Menu Items</h3>
+        <button className="text-sm text-blue-600 hover:text-blue-700 font-medium">View All</button>
+      </div>
+      <div className="space-y-4">
+        {analyticsData.topMenuItems.map((item, index) => (
+          <div key={index} className="flex items-center justify-between p-4 bg-gray-50 rounded-lg">
+            <div className="flex items-center space-x-3">
+              <div className="w-8 h-8 bg-blue-100 rounded-full flex items-center justify-center">
+                <span className="text-sm font-medium text-blue-600">{index + 1}</span>
+              </div>
+              <div>
+                <div className="text-sm font-medium text-gray-900">{item.name}</div>
+                <div className="text-xs text-gray-500">{item.sales} orders • {item.revenue}</div>
+              </div>
+            </div>
+            <div className="text-right">
+              <div className="flex items-center space-x-1 text-sm">
+                <Star className="w-3 h-3 text-yellow-400 fill-current" />
+                <span className="text-gray-900">{item.rating}</span>
+              </div>
+              <div className={`text-xs font-medium ${
+                item.trend.startsWith('+') ? 'text-green-600' : 'text-red-600'
+              }`}>
+                {item.trend}
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+
+  const CustomerMetrics = () => (
+    <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
+      <h3 className="text-lg font-semibold text-gray-900 mb-6">Customer Insights</h3>
+      <div className="grid grid-cols-2 gap-4">
+        {Object.entries(analyticsData.customerMetrics).map(([key, metric]) => (
+          <div key={key} className="text-center p-4 bg-gray-50 rounded-lg">
+            <p className="text-lg font-bold text-gray-900">{metric.value}</p>
+            <p className="text-xs text-gray-500 capitalize mb-1">{key.replace(/([A-Z])/g, ' $1').trim()}</p>
+            <div className={`text-xs font-medium ${
+              metric.isPositive ? 'text-green-600' : 'text-red-600'
+            }`}>
+              {metric.change}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+
+  const PeakHoursChart = () => (
+    <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
+      <div className="flex items-center justify-between mb-6">
+        <h3 className="text-lg font-semibold text-gray-900">Peak Hours Analysis</h3>
+        <div className="flex items-center space-x-2 text-sm text-gray-500">
+          <Clock className="w-4 h-4" />
+          <span>Orders per hour</span>
+        </div>
+      </div>
+      <div className="space-y-3">
+        {analyticsData.peakHours.map((hour, index) => (
+          <div key={index} className="flex items-center justify-between">
+            <div className="flex items-center space-x-3">
+              <span className="text-sm font-medium text-gray-900 w-12">{hour.hour}</span>
+              <div className="flex-1 w-32">
+                <div className="w-full bg-gray-200 rounded-full h-3">
+                  <div
+                    className="bg-blue-600 h-3 rounded-full transition-all duration-300"
+                    style={{ width: `${(hour.orders / 134) * 100}%` }}
+                  ></div>
+                </div>
+              </div>
+              <span className="text-sm text-gray-600 w-8">{hour.orders}</span>
+            </div>
+            <div className="text-right">
+              <span className="text-xs text-gray-500">Efficiency: {hour.efficiency}%</span>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      {/* Header */}
+      <header className="bg-white border-b border-gray-200">
+        <div className="px-6 py-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <h1 className="text-2xl font-bold text-gray-900">Analytics & Reports</h1>
+              <p className="text-sm text-gray-500 mt-1">Comprehensive business insights and performance analytics</p>
+            </div>
+
+            <div className="flex items-center space-x-3">
+              <button
+                onClick={handleRefresh}
+                disabled={isLoading}
+                className="flex items-center space-x-2 px-3 py-2 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors disabled:opacity-50"
+              >
+                <RefreshCw className={`w-4 h-4 ${isLoading ? 'animate-spin' : ''}`} />
+                <span>Refresh</span>
+              </button>
+              <button className="flex items-center space-x-2 px-3 py-2 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
+                <Share className="w-4 h-4" />
+                <span>Share</span>
+              </button>
+              <button className="flex items-center space-x-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors">
+                <Download className="w-4 h-4" />
+                <span>Export Report</span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </header>
+
+      <div className="p-6">
+        {/* Filters and Controls */}
+        <div className="flex flex-col sm:flex-row gap-4 mb-6">
+          <div className="flex items-center space-x-4">
+            <select
+              value={selectedPeriod}
+              onChange={(e) => setSelectedPeriod(e.target.value)}
+              className="px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500"
+            >
+              {periods.map(period => (
+                <option key={period.value} value={period.value}>{period.label}</option>
+              ))}
+            </select>
+
+            <select
+              value={selectedLocation}
+              onChange={(e) => setSelectedLocation(e.target.value)}
+              className="px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500"
+            >
+              {locations.map(location => (
+                <option key={location.value} value={location.value}>{location.label}</option>
+              ))}
+            </select>
+          </div>
+
+          <div className="flex space-x-2 overflow-x-auto">
+            {reportTypes.map(report => (
+              <button
+                key={report.id}
+                onClick={() => setSelectedReport(report.id)}
+                className={`flex items-center space-x-2 px-3 py-2 rounded-lg text-sm font-medium whitespace-nowrap transition-colors ${
+                  selectedReport === report.id
+                    ? 'bg-blue-600 text-white'
+                    : 'bg-white text-gray-700 border border-gray-300 hover:bg-gray-50'
+                }`}
+              >
+                <report.icon className="w-4 h-4" />
+                <span>{report.name}</span>
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Key Metrics */}
+        <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-6 mb-8">
+          <MetricCard
+            title="Total Revenue"
+            value={analyticsData.overview.totalRevenue.value}
+            change={analyticsData.overview.totalRevenue.change}
+            icon={DollarSign}
+            isPositive={analyticsData.overview.totalRevenue.isPositive}
+          />
+          <MetricCard
+            title="Total Orders"
+            value={analyticsData.overview.totalOrders.value}
+            change={analyticsData.overview.totalOrders.change}
+            icon={ShoppingCart}
+            isPositive={analyticsData.overview.totalOrders.isPositive}
+          />
+          <MetricCard
+            title="Avg Order Value"
+            value={analyticsData.overview.avgOrderValue.value}
+            change={analyticsData.overview.avgOrderValue.change}
+            icon={Target}
+            isPositive={analyticsData.overview.avgOrderValue.isPositive}
+          />
+          <MetricCard
+            title="Customer Rating"
+            value={analyticsData.overview.customerSatisfaction.value}
+            change={analyticsData.overview.customerSatisfaction.change}
+            icon={Star}
+            isPositive={analyticsData.overview.customerSatisfaction.isPositive}
+          />
+        </div>
+
+        {/* Main Content */}
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-8">
+          <div className="lg:col-span-2">
+            <RevenueChart />
+          </div>
+          <div className="space-y-6">
+            <CustomerMetrics />
+            <PeakHoursChart />
+          </div>
+        </div>
+
+        {/* Secondary Content */}
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+          <TopLocationsTable />
+          <TopMenuItems />
+        </div>
+
+        {/* Additional Insights */}
+        <div className="mt-8 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+          <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
+            <div className="flex items-center space-x-3 mb-4">
+              <div className="p-2 bg-green-100 rounded-lg">
+                <TrendingUp className="w-5 h-5 text-green-600" />
+              </div>
+              <div>
+                <h3 className="text-lg font-semibold text-gray-900">Growth Insights</h3>
+                <p className="text-sm text-gray-500">Week over week performance</p>
+              </div>
+            </div>
+            <div className="space-y-3">
+              <div className="flex justify-between">
+                <span className="text-sm text-gray-600">Revenue Growth</span>
+                <span className="text-sm font-medium text-green-600">+12.5%</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-sm text-gray-600">New Customers</span>
+                <span className="text-sm font-medium text-green-600">+23.1%</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-sm text-gray-600">Order Frequency</span>
+                <span className="text-sm font-medium text-green-600">+8.3%</span>
+              </div>
+            </div>
+          </div>
+
+          <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
+            <div className="flex items-center space-x-3 mb-4">
+              <div className="p-2 bg-yellow-100 rounded-lg">
+                <AlertTriangle className="w-5 h-5 text-yellow-600" />
+              </div>
+              <div>
+                <h3 className="text-lg font-semibold text-gray-900">Attention Needed</h3>
+                <p className="text-sm text-gray-500">Areas requiring focus</p>
+              </div>
+            </div>
+            <div className="space-y-3">
+              <div className="flex justify-between">
+                <span className="text-sm text-gray-600">Brisbane efficiency</span>
+                <span className="text-sm font-medium text-yellow-600">82%</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-sm text-gray-600">Fish & Chips trend</span>
+                <span className="text-sm font-medium text-red-600">-3%</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-sm text-gray-600">Peak hour wait</span>
+                <span className="text-sm font-medium text-yellow-600">18 min</span>
+              </div>
+            </div>
+          </div>
+
+          <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
+            <div className="flex items-center space-x-3 mb-4">
+              <div className="p-2 bg-blue-100 rounded-lg">
+                <Award className="w-5 h-5 text-blue-600" />
+              </div>
+              <div>
+                <h3 className="text-lg font-semibold text-gray-900">Top Performers</h3>
+                <p className="text-sm text-gray-500">Best performing areas</p>
+              </div>
+            </div>
+            <div className="space-y-3">
+              <div className="flex justify-between">
+                <span className="text-sm text-gray-600">Seoul Gangnam</span>
+                <span className="text-sm font-medium text-blue-600">95% efficiency</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-sm text-gray-600">Bulgogi rating</span>
+                <span className="text-sm font-medium text-blue-600">4.8★</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-sm text-gray-600">Brisbane growth</span>
+                <span className="text-sm font-medium text-blue-600">+18.9%</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AnalyticsReports;

--- a/src/pages/samples/admin/qo-a006-system_settings_fixed.tsx
+++ b/src/pages/samples/admin/qo-a006-system_settings_fixed.tsx
@@ -1,0 +1,429 @@
+import React, { useState } from 'react';
+import {
+  Settings, Shield, CreditCard, Bell,
+  Save, RefreshCw, Upload, Download,
+  Info
+} from 'lucide-react';
+
+const SystemSettings = () => {
+  const [activeTab, setActiveTab] = useState('general');
+  const [isLoading, setIsLoading] = useState(false);
+  const [settings, setSettings] = useState({
+    general: {
+      systemName: 'QR Order Global',
+      timezone: 'Asia/Seoul',
+      language: 'en',
+      currency: 'multi',
+      maintenanceMode: false
+    },
+    notifications: {
+      emailNotifications: true,
+      smsNotifications: false,
+      pushNotifications: true,
+      orderAlerts: true,
+      soundEnabled: true
+    },
+    payments: {
+      stripeEnabled: true,
+      paypalEnabled: true,
+      cardPayments: true,
+      cashPayments: true,
+      taxRate: 10
+    },
+    security: {
+      twoFactorAuth: true,
+      sessionTimeout: 30,
+      passwordPolicy: 'strict',
+      accessLogging: true
+    }
+  });
+
+  const settingsTabs = [
+    { id: 'general', name: 'General', icon: Settings },
+    { id: 'notifications', name: 'Notifications', icon: Bell },
+    { id: 'payments', name: 'Payments', icon: CreditCard },
+    { id: 'security', name: 'Security', icon: Shield }
+  ];
+
+  const handleSave = () => {
+    setIsLoading(true);
+    setTimeout(() => {
+      setIsLoading(false);
+    }, 1500);
+  };
+
+  const updateSetting = (category, key, value) => {
+    setSettings(prev => ({
+      ...prev,
+      [category]: {
+        ...prev[category],
+        [key]: value
+      }
+    }));
+  };
+
+  const ToggleSwitch = ({ enabled, onChange, label, description }) => (
+    <div className="flex items-center justify-between p-4 bg-gray-50 rounded-lg">
+      <div>
+        <div className="text-sm font-medium text-gray-900">{label}</div>
+        {description && <div className="text-xs text-gray-500">{description}</div>}
+      </div>
+      <button
+        onClick={() => onChange(!enabled)}
+        className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
+          enabled ? 'bg-blue-600' : 'bg-gray-300'
+        }`}
+      >
+        <span
+          className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+            enabled ? 'translate-x-6' : 'translate-x-1'
+          }`}
+        />
+      </button>
+    </div>
+  );
+
+  const GeneralSettings = () => (
+    <div className="space-y-6">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-2">System Name</label>
+          <input
+            type="text"
+            value={settings.general.systemName}
+            onChange={(e) => updateSetting('general', 'systemName', e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-2">Timezone</label>
+          <select
+            value={settings.general.timezone}
+            onChange={(e) => updateSetting('general', 'timezone', e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500"
+          >
+            <option value="Asia/Seoul">Asia/Seoul (KST)</option>
+            <option value="Australia/Sydney">Australia/Sydney (AEDT)</option>
+            <option value="Australia/Melbourne">Australia/Melbourne (AEDT)</option>
+            <option value="UTC">UTC</option>
+          </select>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-2">Default Language</label>
+          <select
+            value={settings.general.language}
+            onChange={(e) => updateSetting('general', 'language', e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500"
+          >
+            <option value="en">English</option>
+            <option value="ko">한국어</option>
+            <option value="auto">Auto-detect</option>
+          </select>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-2">Currency Display</label>
+          <select
+            value={settings.general.currency}
+            onChange={(e) => updateSetting('general', 'currency', e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500"
+          >
+            <option value="multi">Multi-currency (KRW/AUD)</option>
+            <option value="krw">Korean Won (₩)</option>
+            <option value="aud">Australian Dollar ($)</option>
+          </select>
+        </div>
+      </div>
+
+      <ToggleSwitch
+        enabled={settings.general.maintenanceMode}
+        onChange={(value) => updateSetting('general', 'maintenanceMode', value)}
+        label="Maintenance Mode"
+        description="Enable to temporarily disable customer access for system updates"
+      />
+    </div>
+  );
+
+  const NotificationSettings = () => (
+    <div className="space-y-6">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <div className="space-y-4">
+          <h4 className="text-sm font-medium text-gray-900">Communication Channels</h4>
+
+          <ToggleSwitch
+            enabled={settings.notifications.emailNotifications}
+            onChange={(value) => updateSetting('notifications', 'emailNotifications', value)}
+            label="Email Notifications"
+            description="Send order updates via email"
+          />
+
+          <ToggleSwitch
+            enabled={settings.notifications.smsNotifications}
+            onChange={(value) => updateSetting('notifications', 'smsNotifications', value)}
+            label="SMS Notifications"
+            description="Send urgent alerts via SMS"
+          />
+
+          <ToggleSwitch
+            enabled={settings.notifications.pushNotifications}
+            onChange={(value) => updateSetting('notifications', 'pushNotifications', value)}
+            label="Push Notifications"
+            description="Browser and mobile push notifications"
+          />
+        </div>
+
+        <div className="space-y-4">
+          <h4 className="text-sm font-medium text-gray-900">Alert Types</h4>
+
+          <ToggleSwitch
+            enabled={settings.notifications.orderAlerts}
+            onChange={(value) => updateSetting('notifications', 'orderAlerts', value)}
+            label="Order Alerts"
+            description="New orders and status updates"
+          />
+
+          <ToggleSwitch
+            enabled={settings.notifications.soundEnabled}
+            onChange={(value) => updateSetting('notifications', 'soundEnabled', value)}
+            label="Sound Notifications"
+            description="Audio alerts for new orders"
+          />
+
+          <div className="p-4 bg-blue-50 rounded-lg">
+            <div className="flex items-center space-x-2 mb-2">
+              <Info className="w-4 h-4 text-blue-600" />
+              <span className="text-sm font-medium text-blue-900">Notification Settings</span>
+            </div>
+            <p className="text-xs text-blue-700">Configure how you receive alerts and updates</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+
+  const PaymentSettings = () => (
+    <div className="space-y-6">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-2">Tax Rate (%)</label>
+          <input
+            type="number"
+            value={settings.payments.taxRate}
+            onChange={(e) => updateSetting('payments', 'taxRate', parseFloat(e.target.value))}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500"
+            min="0"
+            max="30"
+            step="0.1"
+          />
+        </div>
+
+        <div className="p-4 bg-green-50 rounded-lg">
+          <div className="flex items-center space-x-2 mb-2">
+            <CreditCard className="w-4 h-4 text-green-600" />
+            <span className="text-sm font-medium text-green-900">Payment Status</span>
+          </div>
+          <p className="text-xs text-green-700">All payment gateways are operational</p>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <div className="space-y-4">
+          <h4 className="text-sm font-medium text-gray-900">Payment Gateways</h4>
+
+          <ToggleSwitch
+            enabled={settings.payments.stripeEnabled}
+            onChange={(value) => updateSetting('payments', 'stripeEnabled', value)}
+            label="Stripe"
+            description="Credit/debit card processing"
+          />
+
+          <ToggleSwitch
+            enabled={settings.payments.paypalEnabled}
+            onChange={(value) => updateSetting('payments', 'paypalEnabled', value)}
+            label="PayPal"
+            description="PayPal digital wallet"
+          />
+        </div>
+
+        <div className="space-y-4">
+          <h4 className="text-sm font-medium text-gray-900">Payment Methods</h4>
+
+          <ToggleSwitch
+            enabled={settings.payments.cardPayments}
+            onChange={(value) => updateSetting('payments', 'cardPayments', value)}
+            label="Card Payments"
+            description="Credit and debit cards"
+          />
+
+          <ToggleSwitch
+            enabled={settings.payments.cashPayments}
+            onChange={(value) => updateSetting('payments', 'cashPayments', value)}
+            label="Cash Payments"
+            description="Pay at restaurant counter"
+          />
+        </div>
+      </div>
+    </div>
+  );
+
+  const SecuritySettings = () => (
+    <div className="space-y-6">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-2">Session Timeout (minutes)</label>
+          <input
+            type="number"
+            value={settings.security.sessionTimeout}
+            onChange={(e) => updateSetting('security', 'sessionTimeout', parseInt(e.target.value))}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500"
+            min="5"
+            max="480"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-2">Password Policy</label>
+          <select
+            value={settings.security.passwordPolicy}
+            onChange={(e) => updateSetting('security', 'passwordPolicy', e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500"
+          >
+            <option value="basic">Basic (6+ characters)</option>
+            <option value="standard">Standard (8+ chars, mixed case)</option>
+            <option value="strict">Strict (12+ chars, symbols required)</option>
+          </select>
+        </div>
+      </div>
+
+      <div className="space-y-4">
+        <ToggleSwitch
+          enabled={settings.security.twoFactorAuth}
+          onChange={(value) => updateSetting('security', 'twoFactorAuth', value)}
+          label="Two-Factor Authentication"
+          description="Require 2FA for all admin accounts"
+        />
+
+        <ToggleSwitch
+          enabled={settings.security.accessLogging}
+          onChange={(value) => updateSetting('security', 'accessLogging', value)}
+          label="Access Logging"
+          description="Log all user access and actions for security auditing"
+        />
+
+        <div className="p-4 bg-yellow-50 rounded-lg">
+          <div className="flex items-center space-x-2 mb-2">
+            <Shield className="w-4 h-4 text-yellow-600" />
+            <span className="text-sm font-medium text-yellow-900">Security Status</span>
+          </div>
+          <p className="text-xs text-yellow-700">All security features are properly configured</p>
+        </div>
+      </div>
+    </div>
+  );
+
+  const renderTabContent = () => {
+    switch (activeTab) {
+      case 'general': return <GeneralSettings />;
+      case 'notifications': return <NotificationSettings />;
+      case 'payments': return <PaymentSettings />;
+      case 'security': return <SecuritySettings />;
+      default: return <GeneralSettings />;
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      {/* Header */}
+      <header className="bg-white border-b border-gray-200">
+        <div className="px-6 py-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <h1 className="text-2xl font-bold text-gray-900">System Settings</h1>
+              <p className="text-sm text-gray-500 mt-1">Configure global system preferences and integrations</p>
+            </div>
+
+            <div className="flex items-center space-x-3">
+              <button className="flex items-center space-x-2 px-3 py-2 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
+                <Download className="w-4 h-4" />
+                <span>Export</span>
+              </button>
+              <button className="flex items-center space-x-2 px-3 py-2 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
+                <Upload className="w-4 h-4" />
+                <span>Import</span>
+              </button>
+              <button
+                onClick={handleSave}
+                disabled={isLoading}
+                className="flex items-center space-x-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors disabled:opacity-50"
+              >
+                {isLoading ? <RefreshCw className="w-4 h-4 animate-spin" /> : <Save className="w-4 h-4" />}
+                <span>Save Changes</span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </header>
+
+      <div className="flex">
+        {/* Sidebar */}
+        <div className="w-64 bg-white border-r border-gray-200 min-h-screen">
+          <div className="p-4">
+            <nav className="space-y-2">
+              {settingsTabs.map((tab) => (
+                <button
+                  key={tab.id}
+                  onClick={() => setActiveTab(tab.id)}
+                  className={`w-full flex items-center space-x-3 px-3 py-2 rounded-lg text-left transition-colors ${
+                    activeTab === tab.id
+                      ? 'bg-blue-50 text-blue-600 border border-blue-200'
+                      : 'text-gray-700 hover:bg-gray-50'
+                  }`}
+                >
+                  <tab.icon className="w-4 h-4" />
+                  <span className="text-sm font-medium">{tab.name}</span>
+                </button>
+              ))}
+            </nav>
+          </div>
+        </div>
+
+        {/* Main Content */}
+        <div className="flex-1 p-6">
+          <div className="max-w-4xl mx-auto">
+            <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
+              <div className="mb-6">
+                <h2 className="text-lg font-semibold text-gray-900 capitalize">{activeTab} Settings</h2>
+                <p className="text-sm text-gray-500 mt-1">
+                  Configure {activeTab} preferences for your QR Order system
+                </p>
+              </div>
+
+              {renderTabContent()}
+
+              {/* Save Button at bottom */}
+              <div className="mt-8 pt-6 border-t border-gray-200">
+                <div className="flex items-center justify-between">
+                  <div className="text-sm text-gray-500">
+                    Changes are saved automatically when you click Save Changes
+                  </div>
+                  <button
+                    onClick={handleSave}
+                    disabled={isLoading}
+                    className="flex items-center space-x-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors disabled:opacity-50"
+                  >
+                    {isLoading ? <RefreshCw className="w-4 h-4 animate-spin" /> : <Save className="w-4 h-4" />}
+                    <span>Save Changes</span>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SystemSettings;

--- a/src/pages/samples/admin/qo-a007-payment_management.tsx
+++ b/src/pages/samples/admin/qo-a007-payment_management.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const Page = () => {
+  return (
+    <div className="p-6 text-center text-gray-500">
+      <h1 className="text-2xl font-bold mb-4">QO-A007: Payment Management</h1>
+      <p>This page is a placeholder.</p>
+    </div>
+  );
+};
+
+export default Page;

--- a/src/pages/samples/admin/qo-a008-customer_management.tsx
+++ b/src/pages/samples/admin/qo-a008-customer_management.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const Page = () => {
+  return (
+    <div className="p-6 text-center text-gray-500">
+      <h1 className="text-2xl font-bold mb-4">QO-A008: Customer Management</h1>
+      <p>This page is a placeholder.</p>
+    </div>
+  );
+};
+
+export default Page;

--- a/src/pages/samples/admin/qo-a009-inventory_management.tsx
+++ b/src/pages/samples/admin/qo-a009-inventory_management.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const Page = () => {
+  return (
+    <div className="p-6 text-center text-gray-500">
+      <h1 className="text-2xl font-bold mb-4">QO-A009: Inventory Management</h1>
+      <p>This page is a placeholder.</p>
+    </div>
+  );
+};
+
+export default Page;

--- a/src/pages/samples/admin/qo-a010-promotion_management.tsx
+++ b/src/pages/samples/admin/qo-a010-promotion_management.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const Page = () => {
+  return (
+    <div className="p-6 text-center text-gray-500">
+      <h1 className="text-2xl font-bold mb-4">QO-A010: Promotion Management</h1>
+      <p>This page is a placeholder.</p>
+    </div>
+  );
+};
+
+export default Page;

--- a/src/pages/samples/admin/qo-a011-audit_logs.tsx
+++ b/src/pages/samples/admin/qo-a011-audit_logs.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const Page = () => {
+  return (
+    <div className="p-6 text-center text-gray-500">
+      <h1 className="text-2xl font-bold mb-4">QO-A011: Audit Logs</h1>
+      <p>This page is a placeholder.</p>
+    </div>
+  );
+};
+
+export default Page;

--- a/src/pages/samples/admin/qo-a012-qr_code_management.tsx
+++ b/src/pages/samples/admin/qo-a012-qr_code_management.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const Page = () => {
+  return (
+    <div className="p-6 text-center text-gray-500">
+      <h1 className="text-2xl font-bold mb-4">QO-A012: QR Code Management</h1>
+      <p>This page is a placeholder.</p>
+    </div>
+  );
+};
+
+export default Page;


### PR DESCRIPTION
This commit reverts the tablet frame to its original, standard dimensions and restores the entire showcase feature to a fully functional state, addressing all user feedback and correcting previous errors.

- **Reverted Tablet Frame:** The `TabletFrame.tsx` component now uses its original, smaller dimensions (1024x768), as requested by the user.
- **Restored All Pages and Components:** Re-created the `ShowcasePageLayout`, and all 12 admin pages (`qo-a001` to `qo-a012`). The first six admin pages have their full, detailed content and responsive layouts restored, while the latter six have styled placeholders.
- **Restored Showcase Integration:** The `App.tsx` file has been restored to its correct state, using a data-driven approach to route all three user journeys through the `ShowcasePageLayout` with their respective descriptions and device frames.
- **Restored Showcase Page:** The main showcase page (`HomePage.tsx`) has been restored to its enhanced, tabbed-layout version.
- **Restored Navigation Link:** The "Showcase" link on the main landing page has been restored.