### PR TITLE
fix(qo-c002): Align 'Add to Cart' button to bottom of item cards

### DIFF
--- a/src/pages/qo_c002_menu.tsx
+++ b/src/pages/qo_c002_menu.tsx
@@ -124,15 +124,17 @@ const QOMenuCatalog = () => {
           <div key={item.id} className="bg-white rounded-2xl p-4 shadow-sm border border-slate-200">
             <div className="flex space-x-4">
               <div className="w-20 h-20 bg-slate-100 rounded-xl flex items-center justify-center text-3xl">{item.image}</div>
-              <div className="flex-1">
-                <div className="flex items-start justify-between mb-2">
-                  <div>
-                    <div className="flex items-center space-x-2 mb-1">
-                      <h3 className="font-semibold text-slate-900">{item.name[language]}</h3>
-                      {item.tags.includes('popular') && <span className="px-2 py-0.5 bg-orange-100 text-orange-600 text-xs rounded-full font-medium">{currentContent.popular}</span>}
-                      {item.tags.includes('new') && <span className="px-2 py-0.5 bg-blue-100 text-blue-600 text-xs rounded-full font-medium">{currentContent.new}</span>}
+              <div className="flex-1 flex flex-col">
+                <div className="flex-grow">
+                  <div className="flex items-start justify-between mb-2">
+                    <div>
+                      <div className="flex items-center space-x-2 mb-1">
+                        <h3 className="font-semibold text-slate-900">{item.name[language]}</h3>
+                        {item.tags.includes('popular') && <span className="px-2 py-0.5 bg-orange-100 text-orange-600 text-xs rounded-full font-medium">{currentContent.popular}</span>}
+                        {item.tags.includes('new') && <span className="px-2 py-0.5 bg-blue-100 text-blue-600 text-xs rounded-full font-medium">{currentContent.new}</span>}
+                      </div>
+                      <p className="text-sm text-slate-600 leading-relaxed">{item.description[language]}</p>
                     </div>
-                    <p className="text-sm text-slate-600 leading-relaxed">{item.description[language]}</p>
                   </div>
                 </div>
                 <div className="flex items-center justify-between">


### PR DESCRIPTION
This commit resolves a visual bug on the menu page where 'Add to Cart' buttons were not vertically aligned in their respective cards.

The fix refactors the card's internal layout to use flexbox. The main content area is now a flex column, and the description section is set to grow, which pushes the footer of the card (containing the price and button) to the bottom. This creates a uniform and stable layout for all menu items.

This commit also contains the earlier, related refactoring of the item details page (qo-c003).