### PR TITLE
fix(qo-c002): Resolve module export error

### DIFF
--- a/src/components/MenuItemCard.tsx
+++ b/src/components/MenuItemCard.tsx
@@ -14,7 +14,7 @@ export type MenuItemType = {
   reviews: number;
 };
 
-export type CardContent = {
+export type MenuItemCardContent = {
   popular: string;
   new: string;
   vegetarian: string;
@@ -27,7 +27,7 @@ interface MenuItemCardProps {
   currencySymbol: string;
   currencyCode: 'AUD' | 'KRW';
   language: 'en' | 'ko';
-  content: CardContent;
+  content: MenuItemCardContent;
   onAddToCart: (item: MenuItemType) => void;
 }
 

--- a/src/pages/qo_c002_menu.tsx
+++ b/src/pages/qo_c002_menu.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { Search } from 'lucide-react';
 import PageLayout from '../components/PageLayout';
 import { useLanguage } from '../contexts/LanguageContext';
-import MenuItemCard, { MenuItemType, CardContent } from '../components/MenuItemCard';
+import MenuItemCard, { MenuItemType, MenuItemCardContent } from '../components/MenuItemCard';
 
 const QOMenuCatalog = () => {
   const { language, setLanguage } = useLanguage();
@@ -89,7 +89,7 @@ const QOMenuCatalog = () => {
     </div>
   );
 
-  const cardContent: CardContent = {
+  const cardContent: MenuItemCardContent = {
     popular: currentContent.popular,
     new: currentContent.new,
     vegetarian: currentContent.vegetarian,


### PR DESCRIPTION
This commit fixes a runtime error preventing the menu page from loading. The error indicated that the `CardContent` type was not being exported from the `MenuItemCard.tsx` module, even though the code was correct.

This was likely due to a stale cache in the development server. To work around this, the `CardContent` type has been renamed to `MenuItemCardContent` throughout the application to force the bundler to re-evaluate the module.

This also includes the preceding refactoring of the menu page and item card component.